### PR TITLE
feat: 모임 정보 입력 검증 로직 추가

### DIFF
--- a/backend/src/main/java/com/ody/common/annotation/FutureOrPresentDateTime.java
+++ b/backend/src/main/java/com/ody/common/annotation/FutureOrPresentDateTime.java
@@ -1,0 +1,27 @@
+package com.ody.common.annotation;
+
+import com.ody.common.validator.FutureOrPresentDateTimeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = FutureOrPresentDateTimeValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FutureOrPresentDateTime {
+
+    String message() default "날짜와 시간은 현재 이후여야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    String dateFieldName();
+
+    String timeFieldName();
+}

--- a/backend/src/main/java/com/ody/common/validator/FutureOrPresentDateTimeValidator.java
+++ b/backend/src/main/java/com/ody/common/validator/FutureOrPresentDateTimeValidator.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public class FutureOrPresentDateTimeValidator implements ConstraintValidator<FutureOrPresentDateTime, Object> {
+
     private String dateFieldName;
     private String timeFieldName;
 

--- a/backend/src/main/java/com/ody/common/validator/FutureOrPresentDateTimeValidator.java
+++ b/backend/src/main/java/com/ody/common/validator/FutureOrPresentDateTimeValidator.java
@@ -1,0 +1,42 @@
+package com.ody.common.validator;
+
+import com.ody.common.annotation.FutureOrPresentDateTime;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class FutureOrPresentDateTimeValidator implements ConstraintValidator<FutureOrPresentDateTime, Object> {
+    private String dateFieldName;
+    private String timeFieldName;
+
+    @Override
+    public void initialize(FutureOrPresentDateTime constraintAnnotation) {
+        dateFieldName = constraintAnnotation.dateFieldName();
+        timeFieldName = constraintAnnotation.timeFieldName();
+    }
+
+    @Override
+    public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
+        try {
+            Method dateGetter = object.getClass().getMethod(dateFieldName);
+            Method timeGetter = object.getClass().getMethod(timeFieldName);
+
+            LocalDate dateInput = (LocalDate) dateGetter.invoke(object);
+            LocalTime timeInput = (LocalTime) timeGetter.invoke(object);
+
+            LocalDateTime dateTimeInput = LocalDateTime.of(dateInput, timeInput);
+            LocalDateTime now = LocalDateTime.now();
+
+            if (dateInput.isEqual(now.toLocalDate())) {
+                return dateTimeInput.isAfter(now);
+            } else {
+                return dateInput.isAfter(LocalDate.now());
+            }
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}

--- a/backend/src/main/java/com/ody/mate/domain/Mate.java
+++ b/backend/src/main/java/com/ody/mate/domain/Mate.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(uniqueConstraints = {
         @UniqueConstraint(
                 name = "uniqueMeetingAndNickname",
-                columnNames = {"meeting_id", "nickname"}
+                columnNames = {"meeting_id", "nick_name"}
         )
 })
 @Entity
@@ -45,14 +45,15 @@ public class Mate {
     @NotNull
     private Member member;
 
+    @Embedded
     @NotNull
-    private String nickname;
+    private NickName nickname;
 
     @Embedded
     @NotNull
     private Location origin;
 
-    public Mate(Meeting meeting, Member member, String nickname, Location origin) {
+    public Mate(Meeting meeting, Member member, NickName nickname, Location origin) {
         this(null, meeting, member, nickname, origin);
     }
 }

--- a/backend/src/main/java/com/ody/mate/domain/NickName.java
+++ b/backend/src/main/java/com/ody/mate/domain/NickName.java
@@ -1,0 +1,29 @@
+package com.ody.mate.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NickName {
+
+    private static final int MIN_LENGTH = 1;
+    private static final int MAX_LENGTH = 10;
+
+    private String nickName;
+
+    public NickName(String nickName) {
+        validateLength(nickName);
+        this.nickName = nickName;
+    }
+
+    private void validateLength(String nickName) {
+        if (nickName.length() < MIN_LENGTH || nickName.length() >= MAX_LENGTH) {
+            String message = String.format("닉네임은 %d글자 이상, %d자 미만으로 입력 가능합니다.", MIN_LENGTH, MAX_LENGTH);
+            throw new IllegalArgumentException(message);
+        }
+    }
+}

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -4,6 +4,7 @@ import com.ody.meeting.dto.request.MeetingSaveRequest;
 import com.ody.meeting.dto.response.MateResponse;
 import com.ody.meeting.dto.response.MeetingSaveResponse;
 import com.ody.meeting.dto.response.MeetingSaveResponses;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -44,7 +45,7 @@ public class MeetingController implements MeetingControllerSwagger {
     @PostMapping("/meetings")
     public ResponseEntity<MeetingSaveResponse> save(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String fcmToken,
-            @RequestBody MeetingSaveRequest meetingSaveRequest
+            @Valid @RequestBody MeetingSaveRequest meetingSaveRequest
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new MeetingSaveResponse(1L, "우테코 16조", LocalDate.parse("2024-07-15"), LocalTime.parse("14:00"),

--- a/backend/src/main/java/com/ody/meeting/domain/Location.java
+++ b/backend/src/main/java/com/ody/meeting/domain/Location.java
@@ -2,16 +2,17 @@ package com.ody.meeting.domain;
 
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 public class Location {
+
+    private static final List<String> SUPPORT_REGION = List.of("서울", "경기", "인천");
 
     @NotNull
     private String address;
@@ -21,4 +22,19 @@ public class Location {
 
     @NotNull
     private String longitude;
+
+    public Location(String address, String latitude, String longitude) {
+        validateSupportRegion(address);
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    private void validateSupportRegion(String address) {
+        SUPPORT_REGION.stream()
+                .filter(address::startsWith)
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("현재 지원되지 않는 지역입니다."));
+    }
 }
+

--- a/backend/src/main/java/com/ody/meeting/domain/Location.java
+++ b/backend/src/main/java/com/ody/meeting/domain/Location.java
@@ -14,13 +14,8 @@ public class Location {
 
     private static final List<String> SUPPORT_REGION = List.of("서울", "경기", "인천");
 
-    @NotNull
     private String address;
-
-    @NotNull
     private String latitude;
-
-    @NotNull
     private String longitude;
 
     public Location(String address, String latitude, String longitude) {

--- a/backend/src/main/java/com/ody/meeting/dto/request/MeetingSaveRequest.java
+++ b/backend/src/main/java/com/ody/meeting/dto/request/MeetingSaveRequest.java
@@ -1,12 +1,16 @@
 package com.ody.meeting.dto.request;
 
+import com.ody.common.annotation.FutureOrPresentDateTime;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+@FutureOrPresentDateTime(dateFieldName = "date", timeFieldName = "time")
 public record MeetingSaveRequest(
 
         @Schema(description = "모임 이름", example = "우테코 16조")
+        @Size(min = 1, max = 15, message = "약속 이름은 1글자 이상, 16자 미만으로 입력 가능합니다.")
         String name,
 
         @Schema(description = "모임 날짜", example = "2024-07-15")
@@ -25,6 +29,7 @@ public record MeetingSaveRequest(
         String targetLongitude,
 
         @Schema(description = "모임장 닉네임", example = "오디")
+        @Size(min = 1, max = 9, message = "닉네임은 1글자 이상, 10자 미만으로 입력 가능합니다.")
         String nickname,
 
         @Schema(description = "출발지 주소", example = "서울 강남구 테헤란로 411")

--- a/backend/src/test/java/com/ody/common/validator/FutureOrPresentDateTimeValidatorTest.java
+++ b/backend/src/test/java/com/ody/common/validator/FutureOrPresentDateTimeValidatorTest.java
@@ -1,0 +1,96 @@
+package com.ody.common.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.ody.common.annotation.FutureOrPresentDateTime;
+import com.ody.meeting.dto.request.MeetingSaveRequest;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+import java.lang.annotation.Annotation;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class FutureOrPresentDateTimeValidatorTest {
+
+    private FutureOrPresentDateTimeValidator futureOrPresentDateTimeValidator;
+
+    @BeforeEach
+    void init() {
+        futureOrPresentDateTimeValidator = new FutureOrPresentDateTimeValidator();
+        futureOrPresentDateTimeValidator.initialize(new FutureOrPresentDateTime() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return FutureOrPresentDateTime.class;
+            }
+
+            @Override
+            public String dateFieldName() {
+                return "date";
+            }
+
+            @Override
+            public String timeFieldName() {
+                return "time";
+            }
+
+            @Override
+            public String message() {
+                return "날짜와 시간은 현재 이후여야 합니다.";
+            }
+
+            @Override
+            public Class<?>[] groups() {
+                return new Class[0];
+            }
+
+            @Override
+            public Class<? extends Payload>[] payload() {
+                return new Class[0];
+            }
+        });
+    }
+
+    @DisplayName("현재 날짜와 시간 이후면 true, 아니면 false를 반환한다.")
+    @ParameterizedTest
+    @MethodSource("dateTimeTestCases")
+    void isValid(LocalDate date, LocalTime time, boolean expected) {
+        MeetingSaveRequest meetingSaveRequest = new MeetingSaveRequest(
+                "우테코 16조",
+                date,
+                time,
+                "서울 송파구 올림픽로35다길 42",
+                "37.515298",
+                "127.103113",
+                "오디",
+                "서울 강남구 테헤란로 411",
+                "37.505713",
+                "127.050691"
+        );
+
+        boolean valid = futureOrPresentDateTimeValidator.isValid(
+                meetingSaveRequest,
+                mock(ConstraintValidatorContext.class)
+        );
+
+        assertThat(valid).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> dateTimeTestCases() {
+        LocalDate today = LocalDate.now();
+        LocalTime currentTime = LocalTime.now();
+
+        return Stream.of(
+                Arguments.of(today, currentTime, false),
+                Arguments.of(today, currentTime.plusSeconds(1), true),
+                Arguments.of(today, currentTime.minusSeconds(1), false),
+                Arguments.of(today.plusDays(1), currentTime, true)
+        );
+    }
+}

--- a/backend/src/test/java/com/ody/mate/domain/NickNameTest.java
+++ b/backend/src/test/java/com/ody/mate/domain/NickNameTest.java
@@ -1,0 +1,27 @@
+package com.ody.mate.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NickNameTest {
+
+    @DisplayName("닉네임이 1글자 이상, 10자 미만이면 정상적으로 생성된다")
+    @ParameterizedTest
+    @ValueSource(strings = {"k", "abcdefghi"})
+    void createNickNameSuccess(String nickName) {
+        assertThatCode(() -> new NickName(nickName))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("닉네임이 1글자 미만, 10자 이상이면 예외가 발생한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"", "abcdefghij"})
+    void createNickNameException(String nickName) {
+        assertThatThrownBy(() -> new NickName(nickName))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/backend/src/test/java/com/ody/meeting/domain/LocationTest.java
+++ b/backend/src/test/java/com/ody/meeting/domain/LocationTest.java
@@ -1,0 +1,27 @@
+package com.ody.meeting.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class LocationTest {
+
+    @DisplayName("서울, 경기, 인천 지역으로만 Location을 생성할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"서울 강남구 테헤란로 411", "경기 성남시 분당구 서판교로 32", "인천 부평구 갈산로 2"})
+    void createLocationSuccess(String address) {
+        assertThatCode(() -> new Location(address, "123", "123"))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("서울, 경기, 인천 지역이 아니면 Location을 생성시 예외가 발생한다.")
+    @Test
+    void createLocationException() {
+        assertThatThrownBy(() -> new Location("경남 김해시 율하3로 76", "123", "123"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
# 🚩 연관 이슈 
close #58 


<br>

# 📝 작업 내용
모임 정보 입력 검증 로직 추가. 

◦ 모임 이름은 1자 이상, 16자 미만이다.
->DTO에서 validation 어노테이션으로 처리

◦ 모임 날짜, 시간은 개설 시점 이전일 수 없다. 
-> DTO에서 커스텀 validation으로 처리
(현재 날짜와 시간이 분리되어 있는 상황에서 날짜가 오늘이면서 현재시간 이후인지에 대한 검증이 힘들어 `FutureOrPresentDateTime` 커스텀 어노테이션으로 해결)

◦ 모임 장소는 수도권(서울, 경기도, 인천) 내에 있어야 한다.
-> Location 도메인 내부에서 지역이름으로 검증

• 닉네임은 1자 이상, 10자 미만이다.
->DTO에서 validation 어노테이션으로 처리

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)

> 닉네임 검증을 값 객체 사용

닉네임의 경우에는 약속 방을 개설한 사람, 약속 방에 참여한 사람들 모두 검증이 필요한데
`MeetingSaveRequest`, `MateSaveRequest`에서 validation 어노테이션으로 중복 검증을 하는 것 보다
NickName 값 객체로 분리해 공통화 시키는게 좋을 것 같은데 어떻게 생각하시나요 ?