### PR TITLE
feat: 닉네임 입력 화면 구현

### DIFF
--- a/android/app/src/main/java/com/woowacourse/ody/presentation/joininfo/JoinInfoActivity.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/joininfo/JoinInfoActivity.kt
@@ -1,6 +1,7 @@
 package com.woowacourse.ody.presentation.joininfo
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.woowacourse.ody.databinding.ActivityJoinInfoBinding
@@ -13,6 +14,7 @@ class JoinInfoActivity : AppCompatActivity(), BackListener {
     private val binding: ActivityJoinInfoBinding by lazy {
         ActivityJoinInfoBinding.inflate(layoutInflater)
     }
+    private val viewModel: JoinInfoViewModel by viewModels<JoinInfoViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,7 +36,8 @@ class JoinInfoActivity : AppCompatActivity(), BackListener {
         binding.wdJoinInfo.attachTo(binding.vpJoinInfo)
     }
 
-    private fun getJoinInfoFragments(): List<Fragment> = listOf(JoinNickNameFragment(), JoinStartingPointFragment())
+    private fun getJoinInfoFragments(): List<Fragment> =
+        listOf(JoinNickNameFragment(), JoinStartingPointFragment())
 
     override fun onBack() {
         if (binding.vpJoinInfo.currentItem > 0) {

--- a/android/app/src/main/java/com/woowacourse/ody/presentation/joininfo/JoinInfoActivity.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/joininfo/JoinInfoActivity.kt
@@ -36,8 +36,7 @@ class JoinInfoActivity : AppCompatActivity(), BackListener {
         binding.wdJoinInfo.attachTo(binding.vpJoinInfo)
     }
 
-    private fun getJoinInfoFragments(): List<Fragment> =
-        listOf(JoinNickNameFragment(), JoinStartingPointFragment())
+    private fun getJoinInfoFragments(): List<Fragment> = listOf(JoinNickNameFragment(), JoinStartingPointFragment())
 
     override fun onBack() {
         if (binding.vpJoinInfo.currentItem > 0) {

--- a/android/app/src/main/java/com/woowacourse/ody/presentation/joininfo/JoinInfoViewModel.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/joininfo/JoinInfoViewModel.kt
@@ -10,6 +10,10 @@ class JoinInfoViewModel : ViewModel() {
     val nicknameLength: LiveData<Int> = nickname.map { it.length }
     val hasNickname: LiveData<Boolean> = nickname.map { it.isNotEmpty() }
 
+    fun emptyNickname() {
+        nickname.value = ""
+    }
+
     companion object {
         const val NICK_NAME_MAX_LENGTH = 9
     }

--- a/android/app/src/main/java/com/woowacourse/ody/presentation/joininfo/JoinInfoViewModel.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/joininfo/JoinInfoViewModel.kt
@@ -1,8 +1,15 @@
 package com.woowacourse.ody.presentation.joininfo
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
 
 class JoinInfoViewModel : ViewModel() {
+    val nickname: MutableLiveData<String> = MutableLiveData()
+    val nicknameLength: LiveData<Int> = nickname.map { it.length }
+    val hasNickname: LiveData<Boolean> = nickname.map { it.isNotEmpty() }
+
     companion object {
         const val NICK_NAME_MAX_LENGTH = 9
     }

--- a/android/app/src/main/java/com/woowacourse/ody/presentation/joininfo/JoinInfoViewModel.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/joininfo/JoinInfoViewModel.kt
@@ -1,0 +1,9 @@
+package com.woowacourse.ody.presentation.joininfo
+
+import androidx.lifecycle.ViewModel
+
+class JoinInfoViewModel : ViewModel() {
+    companion object {
+        const val NICK_NAME_MAX_LENGTH = 9
+    }
+}

--- a/android/app/src/main/java/com/woowacourse/ody/presentation/nickname/JoinNickNameFragment.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/nickname/JoinNickNameFragment.kt
@@ -24,6 +24,16 @@ class JoinNickNameFragment : Fragment() {
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initializeBinding()
+    }
+
+    private fun initializeBinding() {
+        binding.vm = viewModel
+        binding.lifecycleOwner = viewLifecycleOwner
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null

--- a/android/app/src/main/java/com/woowacourse/ody/presentation/nickname/JoinNickNameFragment.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/nickname/JoinNickNameFragment.kt
@@ -24,7 +24,10 @@ class JoinNickNameFragment : Fragment() {
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
         super.onViewCreated(view, savedInstanceState)
         initializeBinding()
     }

--- a/android/app/src/main/java/com/woowacourse/ody/presentation/nickname/JoinNickNameFragment.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/nickname/JoinNickNameFragment.kt
@@ -5,11 +5,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import com.woowacourse.ody.databinding.FragmentJoinNicknameBinding
+import com.woowacourse.ody.presentation.joininfo.JoinInfoViewModel
 
 class JoinNickNameFragment : Fragment() {
     private var _binding: FragmentJoinNicknameBinding? = null
     private val binding get() = _binding!!
+
+    private val viewModel: JoinInfoViewModel by activityViewModels<JoinInfoViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/android/app/src/main/java/com/woowacourse/ody/util/CommonBindingAdapter.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/util/CommonBindingAdapter.kt
@@ -1,0 +1,12 @@
+package com.woowacourse.ody.util
+
+import android.view.View
+import androidx.databinding.BindingAdapter
+
+object CommonBindingAdapter {
+    @BindingAdapter("visibility")
+    @JvmStatic
+    fun View.setVisibility(isVisible: Boolean?) {
+        visibility = if (isVisible == true) View.VISIBLE else View.GONE
+    }
+}

--- a/android/app/src/main/res/drawable/ic_cancel.xml
+++ b/android/app/src/main/res/drawable/ic_cancel.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#D6D6D6"
+        android:pathData="M22,12C22,17.522 17.522,22 12,22C6.477,22 2,17.522 2,12C2,6.477 6.477,2 12,2C17.522,2 22,6.477 22,12Z" />
+    <path
+        android:fillColor="#FFFFF6"
+        android:pathData="M14.828,7.758L16.242,9.172L9.172,16.242L7.758,14.828L14.828,7.758Z" />
+    <path
+        android:fillColor="#FFFFF6"
+        android:pathData="M16.242,14.828L14.828,16.242L7.758,9.172L9.172,7.758L16.242,14.828Z" />
+</vector>

--- a/android/app/src/main/res/layout/fragment_join_nickname.xml
+++ b/android/app/src/main/res/layout/fragment_join_nickname.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="vm"
+            type="com.woowacourse.ody.presentation.joininfo.JoinInfoViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -54,34 +57,47 @@
             android:inputType="text"
             android:maxLines="1"
             app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
-            app:layout_constraintEnd_toStartOf="@id/tv_nickname_count"
+            app:layout_constraintEnd_toStartOf="@id/tv_nickname_length"
             app:layout_constraintStart_toStartOf="@id/et_nickname_form"
             app:layout_constraintTop_toTopOf="@id/et_nickname_form" />
 
         <TextView
-            android:id="@+id/tv_nickname_count"
+            android:id="@+id/tv_nickname_length"
             style="@style/pretendard_medium_16"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/gray"
             app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
-            app:layout_constraintEnd_toStartOf="@id/tv_nickname_count_form"
+            app:layout_constraintEnd_toStartOf="@id/tv_nickname_length_separator"
             app:layout_constraintStart_toEndOf="@id/et_nickname"
             app:layout_constraintTop_toTopOf="@id/et_nickname_form"
             tools:text="3" />
 
         <TextView
-            android:id="@+id/tv_nickname_count_form"
+            android:id="@+id/tv_nickname_length_separator"
+            style="@style/pretendard_medium_16"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/nickname_length_separator"
+            android:textColor="@color/gray"
+            app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
+            app:layout_constraintEnd_toStartOf="@id/tv_nickname_max_length"
+            app:layout_constraintStart_toEndOf="@id/tv_nickname_length"
+            app:layout_constraintTop_toTopOf="@id/et_nickname_form" />
+
+        <TextView
+            android:id="@+id/tv_nickname_max_length"
             style="@style/pretendard_medium_16"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="5dp"
+            android:text="@{String.valueOf(vm.NICK_NAME_MAX_LENGTH)}"
             android:textColor="@color/gray"
             app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
             app:layout_constraintEnd_toStartOf="@id/iv_cancel"
-            app:layout_constraintStart_toEndOf="@id/tv_nickname_count"
+            app:layout_constraintStart_toEndOf="@id/tv_nickname_length_separator"
             app:layout_constraintTop_toTopOf="@id/et_nickname_form"
-            tools:text="/9" />
+            tools:text="9" />
 
         <ImageView
             android:id="@+id/iv_cancel"
@@ -90,7 +106,7 @@
             android:src="@drawable/ic_cancel"
             app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
             app:layout_constraintEnd_toEndOf="@id/et_nickname_form"
-            app:layout_constraintStart_toEndOf="@id/tv_nickname_count_form"
+            app:layout_constraintStart_toEndOf="@id/tv_nickname_max_length"
             app:layout_constraintTop_toTopOf="@id/et_nickname_form" />
 
         <Button

--- a/android/app/src/main/res/layout/fragment_join_nickname.xml
+++ b/android/app/src/main/res/layout/fragment_join_nickname.xml
@@ -117,7 +117,7 @@
         <Button
             android:id="@+id/btn_next_nickname"
             style="@style/bottom_button_style"
-            android:enabled="false"
+            android:enabled="@{vm.hasNickname}"
             android:text="@string/next_button"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/android/app/src/main/res/layout/fragment_join_nickname.xml
+++ b/android/app/src/main/res/layout/fragment_join_nickname.xml
@@ -1,20 +1,106 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
     </data>
 
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".presentation.nickname.JoinNickNameFragment">
+        android:layout_height="match_parent">
 
         <TextView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:text="닉네임 화면" />
+            android:id="@+id/tv_nickname_front"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="52dp"
+            android:text="@string/nickname_question_front"
+            android:textColor="@color/purple"
+            app:layout_constraintEnd_toStartOf="@id/tv_nickname_back"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    </FrameLayout>
+        <TextView
+            android:id="@+id/tv_nickname_back"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/nickname_question_back"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/tv_nickname_front"
+            app:layout_constraintTop_toTopOf="@id/tv_nickname_front" />
+
+        <EditText
+            android:id="@+id/et_nickname_form"
+            style="@style/edit_text_style"
+            android:layout_marginHorizontal="42dp"
+            android:layout_marginTop="32dp"
+            android:focusable="false"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_nickname_front" />
+
+        <EditText
+            android:id="@+id/et_nickname"
+            style="@style/edit_text_style"
+            android:layout_width="0dp"
+            android:gravity="center_vertical"
+            android:hint="@string/nickname_question_hint"
+            android:inputType="text"
+            android:maxLines="1"
+            app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
+            app:layout_constraintEnd_toStartOf="@id/tv_nickname_count"
+            app:layout_constraintStart_toStartOf="@id/et_nickname_form"
+            app:layout_constraintTop_toTopOf="@id/et_nickname_form" />
+
+        <TextView
+            android:id="@+id/tv_nickname_count"
+            style="@style/pretendard_medium_16"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/gray"
+            app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
+            app:layout_constraintEnd_toStartOf="@id/tv_nickname_count_form"
+            app:layout_constraintStart_toEndOf="@id/et_nickname"
+            app:layout_constraintTop_toTopOf="@id/et_nickname_form"
+            tools:text="3" />
+
+        <TextView
+            android:id="@+id/tv_nickname_count_form"
+            style="@style/pretendard_medium_16"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="5dp"
+            android:textColor="@color/gray"
+            app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
+            app:layout_constraintEnd_toStartOf="@id/iv_cancel"
+            app:layout_constraintStart_toEndOf="@id/tv_nickname_count"
+            app:layout_constraintTop_toTopOf="@id/et_nickname_form"
+            tools:text="/9" />
+
+        <ImageView
+            android:id="@+id/iv_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_cancel"
+            app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
+            app:layout_constraintEnd_toEndOf="@id/et_nickname_form"
+            app:layout_constraintStart_toEndOf="@id/tv_nickname_count_form"
+            app:layout_constraintTop_toTopOf="@id/et_nickname_form" />
+
+        <Button
+            android:id="@+id/btn_next_destination"
+            style="@style/bottom_button_style"
+            android:enabled="false"
+            android:text="@string/next_button"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/fragment_join_nickname.xml
+++ b/android/app/src/main/res/layout/fragment_join_nickname.xml
@@ -103,6 +103,7 @@
             tools:text="9" />
 
         <ImageView
+            android:onClick="@{() -> vm.emptyNickname()}"
             android:id="@+id/iv_cancel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -114,7 +115,7 @@
             app:visibility="@{vm.hasNickname}" />
 
         <Button
-            android:id="@+id/btn_next_destination"
+            android:id="@+id/btn_next_nickname"
             style="@style/bottom_button_style"
             android:enabled="false"
             android:text="@string/next_button"

--- a/android/app/src/main/res/layout/fragment_join_nickname.xml
+++ b/android/app/src/main/res/layout/fragment_join_nickname.xml
@@ -55,7 +55,9 @@
             android:gravity="center_vertical"
             android:hint="@string/nickname_question_hint"
             android:inputType="text"
+            android:maxLength="@{vm.NICK_NAME_MAX_LENGTH}"
             android:maxLines="1"
+            android:text="@={vm.nickname}"
             app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
             app:layout_constraintEnd_toStartOf="@id/tv_nickname_length"
             app:layout_constraintStart_toStartOf="@id/et_nickname_form"
@@ -66,6 +68,7 @@
             style="@style/pretendard_medium_16"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="@{String.valueOf(vm.nicknameLength)}"
             android:textColor="@color/gray"
             app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
             app:layout_constraintEnd_toStartOf="@id/tv_nickname_length_separator"
@@ -107,7 +110,8 @@
             app:layout_constraintBottom_toBottomOf="@id/et_nickname_form"
             app:layout_constraintEnd_toEndOf="@id/et_nickname_form"
             app:layout_constraintStart_toEndOf="@id/tv_nickname_max_length"
-            app:layout_constraintTop_toTopOf="@id/et_nickname_form" />
+            app:layout_constraintTop_toTopOf="@id/et_nickname_form"
+            app:visibility="@{vm.hasNickname}" />
 
         <Button
             android:id="@+id/btn_next_destination"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -24,6 +24,11 @@
     <!-- activity_meeting_completion.xml -->
     <string name="meeting_completion_explain">거의 다 왔어요!\n이제 당신을 소개해 주세요</string>
 
+    <!-- fragment_join_nickname.xml -->
+    <string name="nickname_question_front">닉네임</string>
+    <string name="nickname_question_back">을 알려주세요!</string>
+    <string name="nickname_question_hint">올리브</string>
+
     <!-- activity_join_completion.xml -->
     <string name="join_completion_second_explain">약속에 참여했어요!</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="nickname_question_front">닉네임</string>
     <string name="nickname_question_back">을 알려주세요!</string>
     <string name="nickname_question_hint">올리브</string>
+    <string name="nickname_length_separator">/</string>
+
 
     <!-- activity_join_completion.xml -->
     <string name="join_completion_second_explain">약속에 참여했어요!</string>


### PR DESCRIPTION
# 🚩 연관 이슈 
close #26 


<br>

# 📝 작업 내용
- [x] 닉네임 길이 유효성 검증
- [x] 닉네임 입력할 때마다 길이를 화면에 표시
- [x] 닉네임 길이에 따라 엑스 버튼 visibility, 다음 버튼 enable 변경

<br>

# 🏞️ 스크린샷 (선택)

https://github.com/user-attachments/assets/0b845f0b-7200-41a8-8510-9685fd93777e



<br>

# 🗣️ 리뷰 요구사항 (선택)

- 엑스 버튼 클릭 리스너는 뷰모델 함수로 구현할 수 있어서, 따로 리스너 인터페이스를 만들지 않았습니다. 어차피 xml에는 뷰모델 전체를 전달하기 때문에 인터페이스로 구현해도 동일해질 것 같아서요... 이 경우에도 인터페이스 구현하는 것을 선호하시나요 다들??
- 현재 키보드가 올라오면 하단 다음 버튼이 보이지 않습니다. 이거 adjustResize 속성만 지정하면 되는 거같은데 추후에 해보겠습니다 ㅜ 잘 안됨
