### PR TITLE
feat: 초대코드 검증 API 추가

### DIFF
--- a/backend/src/main/java/com/ody/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ody/common/exception/GlobalExceptionHandler.java
@@ -12,4 +12,9 @@ public class GlobalExceptionHandler {
     public ProblemDetail handleArgumentException(OdyException exception) {
         return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, exception.getMessage());
     }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ProblemDetail notFoundExceptionHandler(NotFoundException exception) {
+        return ProblemDetail.forStatusAndDetail(NotFoundException.HTTP_STATUS, exception.getMessage());
+    }
 }

--- a/backend/src/main/java/com/ody/common/exception/NotFoundException.java
+++ b/backend/src/main/java/com/ody/common/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.ody.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends RuntimeException {
+    public static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -5,10 +5,12 @@ import com.ody.meeting.dto.request.MeetingSaveRequest;
 import com.ody.meeting.dto.response.MateResponse;
 import com.ody.meeting.dto.response.MeetingSaveResponse;
 import com.ody.meeting.dto.response.MeetingSaveResponses;
+import com.ody.meeting.service.MeetingService;
 import com.ody.member.domain.Member;
 import com.ody.notification.domain.Notification;
 import com.ody.notification.dto.response.NotiLogFindResponses;
 import com.ody.notification.service.NotificationService;
+import com.ody.util.InviteCodeGenerator;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -24,11 +26,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
-@Slf4j
 public class MeetingController implements MeetingControllerSwagger {
 
+    private final MeetingService meetingService;
     private final NotificationService notificationService;
 
     @Override
@@ -94,6 +97,7 @@ public class MeetingController implements MeetingControllerSwagger {
             @AuthMember Member member,
             @PathVariable String inviteCode
     ) {
+        InviteCodeGenerator.decode(inviteCode);
         return ResponseEntity.ok()
                 .build();
     }

--- a/backend/src/test/java/com/ody/meeting/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/ody/meeting/controller/MeetingControllerTest.java
@@ -43,12 +43,28 @@ class MeetingControllerTest extends BaseControllerTest {
         RestAssured.given()
                 .log()
                 .all()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer device-token=" + Fixture.MEMBER1.getDeviceToken().getDeviceToken())
+                .header(HttpHeaders.AUTHORIZATION,
+                        "Bearer device-token=" + Fixture.MEMBER1.getDeviceToken().getDeviceToken())
                 .when()
                 .get("/meetings/1/noti-log")
                 .then()
                 .log()
                 .all()
                 .statusCode(200);
+    }
+
+    @DisplayName("유효하지 않은 초대 코드일 경우 400 에러를 반환한다.")
+    @Test
+    void validateInviteCode() {
+        String deviceToken = "Bearer device-token=testToken";
+
+        RestAssured.given()
+                .header(HttpHeaders.AUTHORIZATION, deviceToken)
+                .when()
+                .get("/invite-codes/1/validate")
+                .then()
+                .log()
+                .all()
+                .statusCode(400);
     }
 }

--- a/backend/src/test/java/com/ody/meeting/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/ody/meeting/controller/MeetingControllerTest.java
@@ -8,8 +8,10 @@ import com.ody.mate.repository.MateRepository;
 import com.ody.meeting.domain.Location;
 import com.ody.meeting.domain.Meeting;
 import com.ody.meeting.repository.MeetingRepository;
+import com.ody.member.domain.DeviceToken;
 import com.ody.member.domain.Member;
 import com.ody.member.repository.MemberRepository;
+import com.ody.member.service.MemberService;
 import io.restassured.RestAssured;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -19,6 +21,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 
 class MeetingControllerTest extends BaseControllerTest {
+
+    @Autowired
+    MemberService memberService;
 
     @Autowired
     MeetingRepository meetingRepository;
@@ -53,18 +58,19 @@ class MeetingControllerTest extends BaseControllerTest {
                 .statusCode(200);
     }
 
-    @DisplayName("유효하지 않은 초대 코드일 경우 400 에러를 반환한다.")
+    @DisplayName("유효하지 않은 초대 코드일 경우 404 에러를 반환한다.")
     @Test
     void validateInviteCode() {
         String deviceToken = "Bearer device-token=testToken";
+        memberService.save(new DeviceToken(deviceToken));
 
         RestAssured.given()
                 .header(HttpHeaders.AUTHORIZATION, deviceToken)
                 .when()
-                .get("/invite-codes/1/validate")
+                .get("/invite-codes/testcode/validate")
                 .then()
                 .log()
                 .all()
-                .statusCode(400);
+                .statusCode(404);
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #118 


<br>

# 📝 작업 내용
- 초대 코드 검증 API 추가\
- 404 에러를 반환해야 해 404를 반환할 커스텀 예외 추가

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
#121 

- 위 PR에 있는 DatabaseCleaner가 추가되지 않으면 독립적인 테스트가 안되서 테스트가 실패하는 상황이 생깁니다. 
현재는 트랜잭션 어노테이션으로 테스트 통과를 확인하고 충돌 방지로 해당 어노테이션을 제거했습니다.

- 위 PR에 있는 InvateGenerator를 util로 분리한 코드에 맞게 적용해서
변경된 InvateGenerator는 따로 커밋하지 않았어요 

- 검증 로직 중복
InvateGenerator에서 decode 시 올바른 초대코드형식이 아닐 경우 예외가 발생하도록 되어 있는데
위 PR에서 /mates Post 요청 시에 잘못된 초대코드로 요청을 하면 404에러가 발생하게 되어 있어요

그런데 이번에 추가한 `/invite-codes/{inviteCode}/validate` 요청 API도 
InvateGenerator.decode()로 동일하게 검증을 하고 예외 발생 시 404응답을 주는데 
API 문서를 이미 이렇게 작성해서 데모데이 때는 그대로 진행하는게 맞겠지만 너무 중복적인 로직이라 느껴져 필요한가 싶네요
해당 API가 필요한 리뷰어님들의 의견이 궁금합니다