### PR TITLE
fix: 회원 생성, 모임 참여 API 오류 수정

### DIFF
--- a/backend/src/main/java/com/ody/mate/domain/Mate.java
+++ b/backend/src/main/java/com/ody/mate/domain/Mate.java
@@ -23,6 +23,10 @@ import lombok.NoArgsConstructor;
         @UniqueConstraint(
                 name = "uniqueMeetingAndNickname",
                 columnNames = {"meeting_id", "nickname"}
+        ),
+        @UniqueConstraint(
+                name = "uniqueMeetingAndMember",
+                columnNames = {"meeting_id", "member_id"}
         )
 })
 @Entity

--- a/backend/src/main/java/com/ody/mate/repository/MateRepository.java
+++ b/backend/src/main/java/com/ody/mate/repository/MateRepository.java
@@ -7,4 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MateRepository extends JpaRepository<Mate, Long> {
 
     List<Mate> findAllByMeetingId(Long meetingId);
+
+    boolean existsByMeetingIdAndNicknameNickname(Long meetingId, String nickname);
+
+    boolean existsByMeetingIdAndMemberId(Long memberId, Long meetingId);
 }

--- a/backend/src/main/java/com/ody/mate/service/MateService.java
+++ b/backend/src/main/java/com/ody/mate/service/MateService.java
@@ -1,5 +1,6 @@
 package com.ody.mate.service;
 
+import com.ody.common.exception.OdyException;
 import com.ody.mate.domain.Mate;
 import com.ody.mate.dto.request.MateSaveRequest;
 import com.ody.mate.repository.MateRepository;
@@ -19,6 +20,13 @@ public class MateService {
 
     @Transactional
     public Mate save(MateSaveRequest mateSaveRequest, Meeting meeting, Member member) {
+        if (mateRepository.existsByMeetingIdAndNicknameNickname(meeting.getId(), mateSaveRequest.nickname())) {
+            throw new OdyException("모임 내 같은 닉네임이 존재합니다.");
+        }
+
+        if (mateRepository.existsByMeetingIdAndMemberId(meeting.getId(), member.getId())) {
+            throw new OdyException("모임에 이미 참여한 회원입니다.");
+        }
         return mateRepository.save(mateSaveRequest.toMate(meeting, member));
     }
 

--- a/backend/src/main/java/com/ody/member/domain/DeviceToken.java
+++ b/backend/src/main/java/com/ody/member/domain/DeviceToken.java
@@ -19,12 +19,20 @@ public class DeviceToken {
 
     public DeviceToken(String deviceToken) {
         validatePrefix(deviceToken);
-        this.deviceToken = deviceToken.substring(DEVICE_TOKEN_PREFIX.length());
+        String token = deviceToken.substring(DEVICE_TOKEN_PREFIX.length());
+        validateBlank(token);
+        this.deviceToken = token;
     }
 
     private void validatePrefix(String value) {
         if (!value.startsWith(DEVICE_TOKEN_PREFIX)) {
             throw new OdyException("잘못된 토큰 형식입니다.");
+        }
+    }
+
+    private void validateBlank(String token) {
+        if (token.isBlank()) {
+            throw new OdyException("토큰 값은 공백이 될 수 없습니다.");
         }
     }
 }

--- a/backend/src/main/java/com/ody/member/domain/DeviceToken.java
+++ b/backend/src/main/java/com/ody/member/domain/DeviceToken.java
@@ -1,6 +1,7 @@
 package com.ody.member.domain;
 
 import com.ody.common.exception.OdyException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -13,6 +14,7 @@ public class DeviceToken {
 
     private static final String DEVICE_TOKEN_PREFIX = "Bearer device-token=";
 
+    @Column(unique = true, nullable = false)
     private String deviceToken;
 
     public DeviceToken(String deviceToken) {

--- a/backend/src/main/java/com/ody/member/domain/DeviceToken.java
+++ b/backend/src/main/java/com/ody/member/domain/DeviceToken.java
@@ -19,7 +19,8 @@ public class DeviceToken {
 
     public DeviceToken(String deviceToken) {
         validatePrefix(deviceToken);
-        String token = deviceToken.substring(DEVICE_TOKEN_PREFIX.length());
+        String token = deviceToken.substring(DEVICE_TOKEN_PREFIX.length())
+                .strip();
         validateBlank(token);
         this.deviceToken = token;
     }

--- a/backend/src/main/java/com/ody/member/domain/Member.java
+++ b/backend/src/main/java/com/ody/member/domain/Member.java
@@ -22,8 +22,6 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    @Column(unique = true)
     @Embedded
     private DeviceToken deviceToken;
 

--- a/backend/src/main/java/com/ody/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/ody/member/repository/MemberRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByDeviceToken(DeviceToken deviceToken);
+    Optional<Member> findFirstByDeviceToken(DeviceToken deviceToken);
 }

--- a/backend/src/main/java/com/ody/member/service/MemberService.java
+++ b/backend/src/main/java/com/ody/member/service/MemberService.java
@@ -1,7 +1,7 @@
 package com.ody.member.service;
 
-import com.ody.member.domain.DeviceToken;
 import com.ody.common.exception.OdyException;
+import com.ody.member.domain.DeviceToken;
 import com.ody.member.domain.Member;
 import com.ody.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public class MemberService {
     }
 
     public Member findByDeviceToken(DeviceToken deviceToken) {
-        return memberRepository.findByDeviceToken(deviceToken)
+        return memberRepository.findFirstByDeviceToken(deviceToken)
                 .orElseThrow(() -> new OdyException("존재하지 않는 회원 입니다."));
     }
 }

--- a/backend/src/main/java/com/ody/member/service/MemberService.java
+++ b/backend/src/main/java/com/ody/member/service/MemberService.java
@@ -17,6 +17,9 @@ public class MemberService {
 
     @Transactional
     public Member save(DeviceToken deviceToken) {
+        if (memberRepository.findFirstByDeviceToken(deviceToken).isPresent()) {
+            throw new OdyException("중복된 토큰이 존재합니다.");
+        }
         return memberRepository.save(new Member(deviceToken));
     }
 

--- a/backend/src/test/java/com/ody/meeting/controller/MeetingControllerTest.java
+++ b/backend/src/test/java/com/ody/meeting/controller/MeetingControllerTest.java
@@ -1,21 +1,18 @@
 package com.ody.meeting.controller;
 
 import com.ody.common.BaseControllerTest;
+import com.ody.common.Fixture;
+import com.ody.mate.dto.request.MateSaveRequest;
+import com.ody.mate.service.MateService;
+import com.ody.meeting.domain.Location;
+import com.ody.meeting.domain.Meeting;
 import com.ody.meeting.dto.request.MeetingSaveRequest;
+import com.ody.meeting.service.MeetingService;
 import com.ody.member.domain.DeviceToken;
+import com.ody.member.domain.Member;
 import com.ody.member.service.MemberService;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import com.ody.common.Fixture;
-import com.ody.mate.domain.Mate;
-import com.ody.mate.domain.Nickname;
-import com.ody.mate.repository.MateRepository;
-import com.ody.meeting.domain.Location;
-import com.ody.meeting.domain.Meeting;
-import com.ody.meeting.repository.MeetingRepository;
-import com.ody.member.domain.Member;
-import com.ody.member.repository.MemberRepository;
-import io.restassured.RestAssured;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.jupiter.api.DisplayName;
@@ -28,7 +25,7 @@ class MeetingControllerTest extends BaseControllerTest {
 
     @Autowired
     private MemberService memberService;
-  
+
     @Autowired
     private MeetingService meetingService;
 

--- a/backend/src/test/java/com/ody/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/ody/member/repository/MemberRepositoryTest.java
@@ -17,10 +17,10 @@ class MemberRepositoryTest {
 
     @DisplayName("기기 토큰으로 회원을 조회한다")
     @Test
-    void findByDeviceToken() {
+    void findFirstByDeviceToken() {
         Member member = memberRepository.save(Fixture.MEMBER1);
 
-        Member findMember = memberRepository.findByDeviceToken(member.getDeviceToken()).get();
+        Member findMember = memberRepository.findFirstByDeviceToken(member.getDeviceToken()).get();
 
         assertThat(findMember.getId()).isEqualTo(member.getId());
     }


### PR DESCRIPTION
# 🚩 연관 이슈 
#121 가 merge 되기 전에, 먼저 merge 해야 합니다!

close #120 
<br>

# 📝 작업 내용
## 회원 생성 API
- [x] device-token의 unique 설정 적용
- [x] 토큰 중복 검증 로직 추가
- [x] device-token이 notnull 설정 적용
- [x] device-token에 공백이 저장되지 않도록 변경
- [x] device-token 저장 시 앞뒤 공백 제거 로직 추가

## 모임 참여 API
- [x] 기참여자 검증 로직 추가
  - [x] mate 테이블의 memberId, meetingId unique 설정
- [x] 모임 내 중복 닉네임 검증 로직 추가
- [x] findByDeviceToken 쿼리 메서드에 First 키워드 추가
<details><summary>참고</summary>

![image](https://github.com/user-attachments/assets/75b90008-938e-4f06-96d0-290201b114bb)

![image](https://github.com/user-attachments/assets/0b0bdfb6-2288-4925-b5c3-27c0141b9227)
</details>


# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
