### PR TITLE
feat: Notification 구현

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.datastore.core.android)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -72,7 +72,7 @@
             tools:ignore="DiscouragedApi,LockedOrientationActivity" />
 
         <service
-            android:name=".data.local.FCMService"
+            android:name=".data.remote.FCMService"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/android/app/src/main/java/com/woowacourse/ody/data/local/FCMService.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/data/local/FCMService.kt
@@ -1,16 +1,87 @@
 package com.woowacourse.ody.data.local
 
+import android.R
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.media.RingtoneManager
+import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.woowacourse.ody.data.remote.MemberService
 import com.woowacourse.ody.data.remote.RetrofitClient
+import com.woowacourse.ody.presentation.IntroActivity
 import com.woowacourse.ody.data.remote.service.MemberService
 import kotlinx.coroutines.runBlocking
 
 class FCMService : FirebaseMessagingService() {
+    override fun onMessageReceived(message: RemoteMessage) {
+        val title = message.getNotification()?.title
+        val msg = message.getNotification()?.body
+        notify(title, msg)
+    }
+
+    private fun notify(
+        title: String?,
+        msg: String?,
+    ) {
+        val intent = Intent(this, IntroActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+
+        val contentIntent =
+            PendingIntent.getActivity(
+                this,
+                0,
+                Intent(
+                    this,
+                    IntroActivity::class.java,
+                ),
+                PendingIntent.FLAG_IMMUTABLE,
+            )
+
+        val mBuilder: NotificationCompat.Builder =
+            NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+                .setContentTitle(title)
+                .setSmallIcon(R.mipmap.sym_def_app_icon)
+                .setContentText(msg)
+                .setAutoCancel(true)
+                .setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
+                .setVibrate(longArrayOf(1, 1000))
+
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+        notificationManager.notify(0, mBuilder.build())
+
+        mBuilder.setContentIntent(contentIntent)
+    }
+
+    private fun setNotificationChannel() {
+        val importance = NotificationManager.IMPORTANCE_HIGH
+        val mChannel =
+            NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                NOTIFICATION_CHANNEL_NAME,
+                importance,
+            )
+        mChannel.description = NOTIFICATION_DESCRIPTION
+
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(mChannel)
+    }
+
     override fun onNewToken(token: String) {
         val retrofit = RetrofitClient.retrofit
         val memberService = retrofit.create(MemberService::class.java)
         runBlocking {
             memberService.postMember()
         }
+        setNotificationChannel()
+    }
+
+    companion object {
+        const val NOTIFICATION_CHANNEL_NAME = "notification_channel_name"
+        const val NOTIFICATION_DESCRIPTION = "notification_description_name"
+        const val NOTIFICATION_CHANNEL_ID = "notification_id"
     }
 }

--- a/android/app/src/main/java/com/woowacourse/ody/data/local/FCMService.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/data/local/FCMService.kt
@@ -9,10 +9,9 @@ import android.media.RingtoneManager
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.woowacourse.ody.data.remote.MemberService
 import com.woowacourse.ody.data.remote.RetrofitClient
-import com.woowacourse.ody.presentation.IntroActivity
 import com.woowacourse.ody.data.remote.service.MemberService
+import com.woowacourse.ody.presentation.intro.IntroActivity
 import kotlinx.coroutines.runBlocking
 
 class FCMService : FirebaseMessagingService() {

--- a/android/app/src/main/java/com/woowacourse/ody/data/remote/FCMService.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/data/remote/FCMService.kt
@@ -26,15 +26,15 @@ class FCMService : FirebaseMessagingService() {
     ): String =
         when (type) {
             NotificationType.ENTRY -> {
-                getString(R.string.item_notification_entry, nickname)
+                getString(R.string.fcm_notification_entry, nickname)
             }
 
             NotificationType.DEPARTURE_REMINDER -> {
-                getString(R.string.item_notification_departure_reminder, nickname)
+                getString(R.string.fcm_notification_departure_reminder, nickname)
             }
 
             NotificationType.DEPARTURE -> {
-                getString(R.string.item_notification_departure, nickname)
+                getString(R.string.fcm_notification_departure, nickname)
             }
 
             NotificationType.DEFAULT -> {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,12 @@
     <string name="app_name">오디</string>
     <!-- activity_notification_log -->
     <string name="activity_notification_mates">%1$d명 / %2$s </string>"
+
+    <!-- fcm_notification -->
+    <string name="fcm_notification_entry">%1$s (이)가 들어왔어요.</string>"
+    <string name="fcm_notification_departure_reminder">%1$s (이)가 출발할 시간이에요!</string>"
+    <string name="fcm_notification_departure">%1$s (이)가 출발했어요.</string>"
+
     <!-- item_notification_log.xml -->
     <string name="item_notification_entry">-> %1$s (이)가 들어왔어요.</string>"
     <string name="item_notification_departure_reminder">-> %1$s (이)가 출발할 시간이에요!</string>"

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ appcompat = "1.7.0"
 constraintlayout = "2.1.4"
 coreKtx = "1.13.1"
 datastorePreferences = "1.1.1"
+datastoreCoreAndroid = "1.1.1"
 dotsindicator = "5.0"
 espressoCore = "3.6.1"
 firebaseBom = "33.1.2"
@@ -68,6 +69,7 @@ timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "tim
 
 # dotsindicator
 dotsibdicator = { group = "com.tbuonomo", name = "dotsindicator", version.ref = "dotsindicator" }
+androidx-datastore-core-android = { group = "androidx.datastore", name = "datastore-core-android", version.ref = "datastoreCoreAndroid" }
 
 [plugins]
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #30


<br>

# 📝 작업 내용
- [x] FCM 푸시 서버에서 메시지가 올 경우 푸시 알림 표시
- [x] 알림 종류에 따라 다른 메시지 표시

<br>

# 🏞️ 스크린샷 (선택)

https://github.com/user-attachments/assets/bd68bfa9-6ed7-4fc7-b2e9-ce1f45beba77

영상은 7초에 시작입니다.

<br>

# 🗣️ 리뷰 요구사항 (선택)
FCMService에 모든 기능을 때려넣는게 그다지 올바른 구현은 아니겠지만,
좋은 구조 생각나지 않아 일단 이대로 올립니다.
FCMService를 data 계층에, Notification 기능을 presenter 계층에 두고,
repository를 통해 호출하는 그런 구조를 생각하고 삽질 조금 하다가, 그냥 날리고 PR 올립니다.
테스트는 postman을 이용했습니다.
