### PR TITLE
fix: FCM 토픽 Malformed topic name 에러 해결

### DIFF
--- a/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
+++ b/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
@@ -15,9 +15,9 @@ public class FcmPushSender {
     public String sendPushNotification(FcmSendRequest fcmSendRequest) {
 
         Message message = Message.builder()
-                .setTopic("/topics/" + fcmSendRequest.topic())
                 .putData("type", fcmSendRequest.notificationType().name())
                 .putData("nickname", fcmSendRequest.nickname())
+                .setTopic(fcmSendRequest.topic())
                 .build();
         try {
             return FirebaseMessaging.getInstance().send(message);

--- a/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
+++ b/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
@@ -4,7 +4,6 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.ody.common.exception.OdyServerErrorException;
-import com.ody.notification.dto.request.EnterMessageRequest;
 import com.ody.notification.dto.request.FcmSendRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/backend/src/main/java/com/ody/notification/service/FcmSubscriber.java
+++ b/backend/src/main/java/com/ody/notification/service/FcmSubscriber.java
@@ -15,9 +15,8 @@ public class FcmSubscriber {
 
     public void subscribeTopic(Meeting meeting, DeviceToken deviceToken) {
         try {
-            String topicName = "/topics/" + meeting.getId().toString();
             TopicManagementResponse topicManagementResponse = FirebaseMessaging.getInstance()
-                    .subscribeToTopic(List.of(deviceToken.getDeviceToken()), topicName);
+                    .subscribeToTopic(List.of(deviceToken.getDeviceToken()), meeting.getId().toString());
             log.info("모임 구독에 성공했습니다 {}", topicManagementResponse);
         } catch (Exception exception) {
             log.error(exception.getMessage());

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -40,7 +40,7 @@ public class NotificationService {
         Notification notification = new Notification(
                 mate,
                 NotificationType.DEPARTURE_REMINDER,
-                sendAt.getValue(),
+                LocalDateTime.now().plusSeconds(30),
                 NotificationStatus.PENDING
         );
         notificationRepository.save(notification);


### PR DESCRIPTION
# 🚩 연관 이슈 
close #150 


<br>

# 📝 작업 내용
FCM 토픽 Malformed topic name 에러 해결
```
2024-07-25T16:13:00.000+09:00 ERROR 1 --- [   scheduling-1] o.s.s.s.TaskUtils$LoggingErrorHandler    : Unexpected error occurred in scheduled task

java.lang.IllegalArgumentException: Malformed topic name
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145) ~[guava-31.1-jre.jar!/:na]
	at com.google.firebase.messaging.Message.stripPrefix(Message.java:149) ~[firebase-admin-9.2.0.jar!/:na]
	at com.google.firebase.messaging.Message.<init>(Message.java:82) ~[firebase-admin-9.2.0.jar!/:na]
	at com.google.firebase.messaging.Message.<init>(Message.java:40) ~[firebase-admin-9.2.0.jar!/:na]
	at com.google.firebase.messaging.Message$Builder.build(Message.java:295) ~[firebase-admin-9.2.0.jar!/:na]
	at com.ody.notification.service.FcmPushSender.sendPushNotification(FcmPushSender.java:20) ~[!/:0.0.1-SNAPSHOT]
	at com.ody.notification.service.FcmEventScheduler.lambda$addDepartureNotification$0(FcmEventScheduler.java:26) ~[!/:0.0.1-SNAPSHOT]
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-6.1.10.jar!/:6.1.10]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[na:na]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[na:na]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:833) ~[na:na]
```

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
