### PR TITLE
refactor: DTO 변환을 담당하는 계층을 컨트롤러에서만 담당하도록 수정

### DIFF
--- a/backend/src/main/java/com/ody/mate/controller/MateController.java
+++ b/backend/src/main/java/com/ody/mate/controller/MateController.java
@@ -32,10 +32,10 @@ public class MateController implements MateControllerSwagger {
             @AuthMember Member member,
             @RequestBody MateSaveRequest mateSaveRequest
     ) {
-        Long meetingId = InviteCodeGenerator.decode(mateSaveRequest.inviteCode());
-        Meeting meeting = meetingService.findById(meetingId);
-        Mate mate = mateService.save(mateSaveRequest.toMate(meeting, member), meeting);
-        notificationService.saveAndSendDepartureReminder(meeting, mate, member.getDeviceToken());
+        Meeting meeting = meetingService.findById(InviteCodeGenerator.decode(mateSaveRequest.inviteCode()));
+        Mate mate = mateSaveRequest.toMate(meeting, member);
+        mateService.save(mate);
+        notificationService.saveAndSendDepartureReminder(mate.getMeeting(), mate, mate.getMember().getDeviceToken());
         List<Mate> mates = mateService.findAllByMeetingId(meeting.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(MeetingSaveResponse.of(meeting, mates));
     }

--- a/backend/src/main/java/com/ody/mate/controller/MateController.java
+++ b/backend/src/main/java/com/ody/mate/controller/MateController.java
@@ -34,12 +34,9 @@ public class MateController implements MateControllerSwagger {
     ) {
         Long meetingId = InviteCodeGenerator.decode(mateSaveRequest.inviteCode());
         Meeting meeting = meetingService.findById(meetingId);
-        Mate mate = mateService.save(mateSaveRequest, meeting, member);
-
+        Mate mate = mateService.save(mateSaveRequest.toMate(meeting, member), meeting);
         notificationService.saveAndSendDepartureReminder(meeting, mate, member.getDeviceToken());
-
         List<Mate> mates = mateService.findAllByMeetingId(meeting.getId());
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(MeetingSaveResponse.of(meeting, mates));
+        return ResponseEntity.status(HttpStatus.CREATED).body(MeetingSaveResponse.of(meeting, mates));
     }
 }

--- a/backend/src/main/java/com/ody/mate/controller/MateController.java
+++ b/backend/src/main/java/com/ody/mate/controller/MateController.java
@@ -35,8 +35,7 @@ public class MateController implements MateControllerSwagger {
         Meeting meeting = meetingService.findById(InviteCodeGenerator.decode(mateSaveRequest.inviteCode()));
         Mate mate = mateSaveRequest.toMate(meeting, member);
         mateService.save(mate);
-        notificationService.saveEntryAndDepartureNotification(mate.getMeeting(), mate,
-                mate.getMember().getDeviceToken());
+        notificationService.saveEntryAndDepartureNotification(mate);
         List<Mate> mates = mateService.findAllByMeetingId(meeting.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(MeetingSaveResponse.of(meeting, mates));
     }

--- a/backend/src/main/java/com/ody/mate/controller/MateController.java
+++ b/backend/src/main/java/com/ody/mate/controller/MateController.java
@@ -35,7 +35,8 @@ public class MateController implements MateControllerSwagger {
         Meeting meeting = meetingService.findById(InviteCodeGenerator.decode(mateSaveRequest.inviteCode()));
         Mate mate = mateSaveRequest.toMate(meeting, member);
         mateService.save(mate);
-        notificationService.saveAndSendDepartureReminder(mate.getMeeting(), mate, mate.getMember().getDeviceToken());
+        notificationService.saveEntryAndDepartureNotification(mate.getMeeting(), mate,
+                mate.getMember().getDeviceToken());
         List<Mate> mates = mateService.findAllByMeetingId(meeting.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(MeetingSaveResponse.of(meeting, mates));
     }

--- a/backend/src/main/java/com/ody/mate/domain/Mate.java
+++ b/backend/src/main/java/com/ody/mate/domain/Mate.java
@@ -60,4 +60,8 @@ public class Mate {
     public Mate(Meeting meeting, Member member, Nickname nickname, Location origin) {
         this(null, meeting, member, nickname, origin);
     }
+
+    public String getNickname() {
+        return nickname.getNickname();
+    }
 }

--- a/backend/src/main/java/com/ody/mate/service/MateService.java
+++ b/backend/src/main/java/com/ody/mate/service/MateService.java
@@ -2,10 +2,7 @@ package com.ody.mate.service;
 
 import com.ody.common.exception.OdyBadRequestException;
 import com.ody.mate.domain.Mate;
-import com.ody.mate.dto.request.MateSaveRequest;
 import com.ody.mate.repository.MateRepository;
-import com.ody.meeting.domain.Meeting;
-import com.ody.member.domain.Member;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,11 +16,14 @@ public class MateService {
     private final MateRepository mateRepository;
 
     @Transactional
-    public Mate save(Mate mate, Meeting meeting) {
-        if (mateRepository.existsByMeetingIdAndNicknameNickname(meeting.getId(), mate.getNickname().getNickname())) {
+    public Mate save(Mate mate) {
+        if (mateRepository.existsByMeetingIdAndNicknameNickname(
+                mate.getMeeting().getId(),
+                mate.getNickname())
+        ) {
             throw new OdyBadRequestException("모임 내 같은 닉네임이 존재합니다.");
         }
-        if (mateRepository.existsByMeetingIdAndMemberId(meeting.getId(), mate.getMember().getId())) {
+        if (mateRepository.existsByMeetingIdAndMemberId(mate.getMeeting().getId(), mate.getMember().getId())) {
             throw new OdyBadRequestException("모임에 이미 참여한 회원입니다.");
         }
         return mateRepository.save(mate);

--- a/backend/src/main/java/com/ody/mate/service/MateService.java
+++ b/backend/src/main/java/com/ody/mate/service/MateService.java
@@ -19,15 +19,14 @@ public class MateService {
     private final MateRepository mateRepository;
 
     @Transactional
-    public Mate save(MateSaveRequest mateSaveRequest, Meeting meeting, Member member) {
-        if (mateRepository.existsByMeetingIdAndNicknameNickname(meeting.getId(), mateSaveRequest.nickname())) {
+    public Mate save(Mate mate, Meeting meeting) {
+        if (mateRepository.existsByMeetingIdAndNicknameNickname(meeting.getId(), mate.getNickname().getNickname())) {
             throw new OdyBadRequestException("모임 내 같은 닉네임이 존재합니다.");
         }
-
-        if (mateRepository.existsByMeetingIdAndMemberId(meeting.getId(), member.getId())) {
+        if (mateRepository.existsByMeetingIdAndMemberId(meeting.getId(), mate.getMember().getId())) {
             throw new OdyBadRequestException("모임에 이미 참여한 회원입니다.");
         }
-        return mateRepository.save(mateSaveRequest.toMate(meeting, member));
+        return mateRepository.save(mate);
     }
 
     public List<Mate> findAllByMeetingId(Long meetingId) {

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -77,7 +77,7 @@ public class MeetingController implements MeetingControllerSwagger {
                 meetingSaveRequest.originLongitude()
         );
         Mate mate = mateService.save(mateSaveRequest.toMate(meeting, member));
-        notificationService.saveEntryAndDepartureNotification(meeting, mate, member.getDeviceToken());
+        notificationService.saveEntryAndDepartureNotification(mate);
 
         List<Mate> mates = mateService.findAllByMeetingId(meeting.getId());
         MeetingSaveResponse meetingSaveResponse = MeetingSaveResponse.of(meeting, mates);

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -76,7 +76,7 @@ public class MeetingController implements MeetingControllerSwagger {
                 meetingSaveRequest.originLatitude(),
                 meetingSaveRequest.originLongitude()
         );
-        Mate mate = mateService.save(mateSaveRequest.toMate(meeting, member), meeting);
+        Mate mate = mateService.save(mateSaveRequest.toMate(meeting, member));
         notificationService.saveAndSendDepartureReminder(meeting, mate, member.getDeviceToken());
 
         List<Mate> mates = mateService.findAllByMeetingId(meeting.getId());

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -77,7 +77,7 @@ public class MeetingController implements MeetingControllerSwagger {
                 meetingSaveRequest.originLongitude()
         );
         Mate mate = mateService.save(mateSaveRequest.toMate(meeting, member));
-        notificationService.saveAndSendDepartureReminder(meeting, mate, member.getDeviceToken());
+        notificationService.saveEntryAndDepartureNotification(meeting, mate, member.getDeviceToken());
 
         List<Mate> mates = mateService.findAllByMeetingId(meeting.getId());
         MeetingSaveResponse meetingSaveResponse = MeetingSaveResponse.of(meeting, mates);

--- a/backend/src/main/java/com/ody/meeting/dto/response/MateResponse.java
+++ b/backend/src/main/java/com/ody/meeting/dto/response/MateResponse.java
@@ -7,7 +7,7 @@ public record MateResponse(String nickname) {
 
     public static List<MateResponse> from(List<Mate> mates) {
         return mates.stream()
-                .map(mate -> new MateResponse(mate.getNickname().getNickname()))
+                .map(mate -> new MateResponse(mate.getNickname()))
                 .toList();
     }
 }

--- a/backend/src/main/java/com/ody/meeting/service/MeetingService.java
+++ b/backend/src/main/java/com/ody/meeting/service/MeetingService.java
@@ -16,16 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MeetingService {
 
-    private static final String DEFAULT_INVITE_CODE = "초대코드";
-
     private final MeetingRepository meetingRepository;
 
     @Transactional
-    public Meeting save(MeetingSaveRequest meetingSaveRequest) {
-        Meeting meeting = meetingRepository.save(meetingSaveRequest.toMeeting(DEFAULT_INVITE_CODE));
+    public Meeting save(Meeting meeting) {
+        Meeting savedMeeting = meetingRepository.save(meeting);
         String encodedInviteCode = InviteCodeGenerator.encode(meeting.getId());
         meeting.updateInviteCode(encodedInviteCode);
-        return meeting;
+        return savedMeeting;
     }
 
     public Meeting findById(Long meetingId) {

--- a/backend/src/main/java/com/ody/notification/dto/response/NotiLogFindResponse.java
+++ b/backend/src/main/java/com/ody/notification/dto/response/NotiLogFindResponse.java
@@ -19,7 +19,7 @@ public record NotiLogFindResponse(
     public NotiLogFindResponse(Notification notification) {
         this(
                 notification.getType().toString(),
-                notification.getMate().getNickname().getNickname(),
+                notification.getMate().getNickname(),
                 notification.getSendAt().withNano(0)
         );
     }

--- a/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
+++ b/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
@@ -23,7 +23,7 @@ public class FcmPushSender {
         Notification notification = notificationService.findById(fcmSendRequest.notificationId());
         Message message = Message.builder()
                 .putData("type", notification.getType().toString())
-                .putData("nickname", notification.getMate().getNickname().getNickname())
+                .putData("nickname", notification.getMate().getNickname())
                 .setTopic(fcmSendRequest.topic())
                 .build();
         try {

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -12,7 +12,6 @@ import com.ody.notification.repository.NotificationRepository;
 import com.ody.route.domain.DepartureTime;
 import com.ody.route.service.RouteService;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,8 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class NotificationService {
 
     private final ApplicationEventPublisher publisher;
@@ -36,7 +35,9 @@ public class NotificationService {
         saveAndSendEntryNotification(meeting, mate);
         fcmSubscriber.subscribeTopic(meeting, deviceToken);
         saveAndSendDepartureNotification(meeting, mate);
-    };
+    }
+
+    ;
 
     private void saveAndSendEntryNotification(Meeting meeting, Mate mate) {
         Notification entryNotification = new Notification(
@@ -73,7 +74,7 @@ public class NotificationService {
         FcmSendRequest fcmSendRequest = new FcmSendRequest(
                 meeting.getId().toString(),
                 savedNotification.getId(),
-                LocalDateTime.now().plusSeconds(10) // TODO: savedNotification.getSendAt() 으로 변경
+                savedNotification.getSendAt()
         );
         publisher.publishEvent(fcmSendRequest);
     }

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -21,8 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class NotificationService {
 
     private final ApplicationEventPublisher publisher;
@@ -31,13 +31,11 @@ public class NotificationService {
     private final RouteService routeService;
 
     @Transactional
-    public void saveAndSendDepartureReminder(Meeting meeting, Mate mate, DeviceToken deviceToken) {
+    public void saveEntryAndDepartureNotification(Meeting meeting, Mate mate, DeviceToken deviceToken) {
         saveAndSendEntryNotification(meeting, mate);
         fcmSubscriber.subscribeTopic(meeting, deviceToken);
         saveAndSendDepartureNotification(meeting, mate);
     }
-
-    ;
 
     private void saveAndSendEntryNotification(Meeting meeting, Mate mate) {
         Notification entryNotification = new Notification(

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -3,7 +3,6 @@ package com.ody.notification.service;
 import com.ody.common.exception.OdyNotFoundException;
 import com.ody.mate.domain.Mate;
 import com.ody.meeting.domain.Meeting;
-import com.ody.member.domain.DeviceToken;
 import com.ody.notification.domain.Notification;
 import com.ody.notification.domain.NotificationStatus;
 import com.ody.notification.domain.NotificationType;
@@ -31,10 +30,10 @@ public class NotificationService {
     private final RouteService routeService;
 
     @Transactional
-    public void saveEntryAndDepartureNotification(Meeting meeting, Mate mate, DeviceToken deviceToken) {
-        saveAndSendEntryNotification(meeting, mate);
-        fcmSubscriber.subscribeTopic(meeting, deviceToken);
-        saveAndSendDepartureNotification(meeting, mate);
+    public void saveEntryAndDepartureNotification(Mate mate) {
+        saveAndSendEntryNotification(mate.getMeeting(), mate);
+        fcmSubscriber.subscribeTopic(mate.getMeeting(), mate.getMember().getDeviceToken());
+        saveAndSendDepartureNotification(mate.getMeeting(), mate);
     }
 
     private void saveAndSendEntryNotification(Meeting meeting, Mate mate) {

--- a/backend/src/test/java/com/ody/mate/controller/MateControllerTest.java
+++ b/backend/src/test/java/com/ody/mate/controller/MateControllerTest.java
@@ -1,16 +1,14 @@
 package com.ody.mate.controller;
 
 import com.ody.common.BaseControllerTest;
+import com.ody.common.Fixture;
 import com.ody.mate.dto.request.MateSaveRequest;
 import com.ody.meeting.domain.Meeting;
-import com.ody.meeting.dto.request.MeetingSaveRequest;
 import com.ody.meeting.service.MeetingService;
 import com.ody.member.domain.DeviceToken;
 import com.ody.member.service.MemberService;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,19 +31,7 @@ class MateControllerTest extends BaseControllerTest {
         String deviceToken = "Bearer device-token=testToken";
         memberService.save(new DeviceToken(deviceToken));
 
-        MeetingSaveRequest meetingRequest = new MeetingSaveRequest(
-                "우테코 16조",
-                LocalDate.parse("2024-07-15"),
-                LocalTime.parse("14:00"),
-                "서울 송파구 올림픽로35다길 42",
-                "37.515298",
-                "127.103113",
-                "오디",
-                "서울 강남구 테헤란로 411",
-                "37.505713",
-                "127.050691"
-        );
-        Meeting meeting = meetingService.save(meetingRequest);
+        Meeting meeting = meetingService.save(Fixture.ODY_MEETING1);
 
         MateSaveRequest mateSaveRequest = new MateSaveRequest(
                 meeting.getInviteCode(),

--- a/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
+++ b/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
@@ -8,8 +8,6 @@ import com.ody.common.Fixture;
 import com.ody.common.exception.OdyBadRequestException;
 import com.ody.mate.domain.Mate;
 import com.ody.mate.domain.Nickname;
-import com.ody.mate.dto.request.MateSaveRequest;
-import com.ody.mate.repository.MateRepository;
 import com.ody.meeting.domain.Meeting;
 import com.ody.meeting.repository.MeetingRepository;
 import com.ody.member.domain.Member;
@@ -27,29 +25,19 @@ class MateServiceTest extends BaseServiceTest {
     private MeetingRepository meetingRepository;
 
     @Autowired
-    private MateRepository mateRepository;
-
-    @Autowired
     private MateService mateService;
 
     @DisplayName("모임 내 닉네임이 중복되지 않으면 모임에 참여한다.")
     @Test
     void saveMate() {
         Member member1 = memberRepository.save(Fixture.MEMBER1);
-        Member member2 = memberRepository.save(Fixture.MEMBER2);
-
         Meeting meeting = meetingRepository.save(Fixture.ODY_MEETING1);
-        mateRepository.save(
-                new Mate(meeting, member1, new Nickname("콜리"), Fixture.ORIGIN_LOCATION)); // TODO: 데이터 클린 작업 필요
+        mateService.save(new Mate(meeting, member1, new Nickname("콜리"), Fixture.ORIGIN_LOCATION));
 
-        MateSaveRequest mateSaveRequest = new MateSaveRequest(
-                meeting.getInviteCode(),
-                "카키",
-                Fixture.ORIGIN_LOCATION.getAddress(),
-                Fixture.ORIGIN_LOCATION.getLatitude(),
-                Fixture.ORIGIN_LOCATION.getLongitude()
-        );
-        assertThatCode(() -> mateService.save(mateSaveRequest, meeting, member2))
+        Member member2 = memberRepository.save(Fixture.MEMBER2);
+        Mate kaki = new Mate(meeting, member2, new Nickname("카키"), Fixture.ORIGIN_LOCATION);
+
+        assertThatCode(() -> mateService.save(kaki))
                 .doesNotThrowAnyException();
     }
 
@@ -57,19 +45,14 @@ class MateServiceTest extends BaseServiceTest {
     @Test
     void saveMateWithDuplicateNickname() {
         Member member1 = memberRepository.save(Fixture.MEMBER1);
-        Member member2 = memberRepository.save(Fixture.MEMBER2);
-
         Meeting meeting = meetingRepository.save(Fixture.ODY_MEETING1);
-        mateRepository.save(new Mate(meeting, member1, new Nickname("제리"), Fixture.ORIGIN_LOCATION));
+        Nickname nickname = new Nickname("콜리");
+        mateService.save(new Mate(meeting, member1, nickname, Fixture.ORIGIN_LOCATION));
 
-        MateSaveRequest mateSaveRequest = new MateSaveRequest(
-                meeting.getInviteCode(),
-                "제리",
-                Fixture.ORIGIN_LOCATION.getAddress(),
-                Fixture.ORIGIN_LOCATION.getLatitude(),
-                Fixture.ORIGIN_LOCATION.getLongitude()
-        );
-        assertThatThrownBy(() -> mateService.save(mateSaveRequest, meeting, member2))
+        Member member2 = memberRepository.save(Fixture.MEMBER2);
+        Mate sameNicknameMate = new Mate(meeting, member2, nickname, Fixture.ORIGIN_LOCATION);
+
+        assertThatThrownBy(() -> mateService.save(sameNicknameMate))
                 .isInstanceOf(OdyBadRequestException.class);
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #176

<br>

# 📝 작업 내용
- DTO 변환을 담당하는 계층을 컨트롤러에서만 담당하도록 수정
- MateService.save(), NotificationService.save() 호출 시 인자로 넘기는 mate 객체에 meeting, member가 이미 초기화되어 있어 불필요하게 넘기는 파라미터 제거
- Mate에서 String 타입의 닉네임을 getter로 가져올 때 getNickname().getNickname()이 디미터 법칙을 위반 및 가독성을 저해한다고 생각해  Mate에서 getter 시 Nickname 타입을 반환하는 것이 아닌 String 타입을 반환하도록 수정

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
약속 방 개설자가  방을 생성하고 참여하는 흐름을 /meetings POST 요청에 다 합치지 않고
/meetings POST, /mates POST 분리되게 요청을 하도록 수정하면 /meetings POST 요청을 매핑하는 컨트롤러 코드가 훨씬 더 깔끔해질 것 같아요
이 부분은 안드로이드 측과 얘기해보면 좋을것 같은데 어떻게 생각하시나요 ?