### PR TITLE
docs: 약속 단건 조회 API 문서화

### DIFF
--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -4,6 +4,7 @@ import com.ody.common.annotation.AuthMember;
 import com.ody.meeting.dto.request.MeetingSaveRequest;
 import com.ody.meeting.dto.response.MeetingSaveResponse;
 import com.ody.meeting.dto.response.MeetingSaveResponses;
+import com.ody.meeting.dto.response.MeetingWithMatesResponse;
 import com.ody.meeting.service.MeetingService;
 import com.ody.member.domain.Member;
 import com.ody.notification.domain.Notification;
@@ -38,6 +39,16 @@ public class MeetingController implements MeetingControllerSwagger {
         MeetingSaveResponse meetingSaveResponse = meetingService.saveAndSendNotifications(meetingSaveRequest, member);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(meetingSaveResponse);
+    }
+
+    @Override
+    @GetMapping("/v1/meetings/{meetingId}")
+    public ResponseEntity<MeetingWithMatesResponse> findMeetingWithMates(
+            @AuthMember Member member,
+            @PathVariable Long meetingId
+    ) {
+        MeetingWithMatesResponse meetingWithMatesResponse = meetingService.findMeetingWithMates(member, meetingId);
+        return ResponseEntity.ok(meetingWithMatesResponse);
     }
 
     @Override

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingControllerSwagger.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingControllerSwagger.java
@@ -3,6 +3,7 @@ package com.ody.meeting.controller;
 import com.ody.meeting.dto.request.MeetingSaveRequest;
 import com.ody.meeting.dto.response.MeetingSaveResponse;
 import com.ody.meeting.dto.response.MeetingSaveResponses;
+import com.ody.meeting.dto.response.MeetingWithMatesResponse;
 import com.ody.member.domain.Member;
 import com.ody.notification.dto.response.NotiLogFindResponses;
 import com.ody.swagger.annotation.ErrorCode400;
@@ -22,6 +23,44 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "Meeting API")
 @SecurityRequirement(name = "Authorization")
 public interface MeetingControllerSwagger {
+
+    @Operation(
+            summary = "모임 개설",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = MeetingSaveRequest.class))),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "모임 개설 성공",
+                            content = @Content(schema = @Schema(implementation = MeetingSaveResponse.class))
+                    )
+            }
+    )
+    @ErrorCode400
+    @ErrorCode401
+    @ErrorCode500
+    ResponseEntity<MeetingSaveResponse> save(
+            @Parameter(hidden = true) Member member,
+            MeetingSaveRequest meetingSaveRequest
+    );
+
+    @Operation(
+            summary = "약속 단건 조회",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "약속 단건 조회 성공",
+                            content = @Content(schema = @Schema(implementation = MeetingWithMatesResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "존재하지 않는 약속이거나 해당 약속 참여자가 아닌 경우",
+                            content = @Content(schema = @Schema(implementation = ProblemDetail.class))
+                    )
+            }
+    )
+    @ErrorCode401
+    @ErrorCode500
+    ResponseEntity<MeetingWithMatesResponse> findMeetingWithMates(@Parameter(hidden = true) Member member, Long meetingId);
 
     @Operation(
             summary = "참여중인 모임 목록 조회",
@@ -55,25 +94,6 @@ public interface MeetingControllerSwagger {
     @ErrorCode401
     @ErrorCode500
     ResponseEntity<NotiLogFindResponses> findAllMeetingLogs(@Parameter(hidden = true) Member member, Long meetingId);
-
-    @Operation(
-            summary = "모임 개설",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = MeetingSaveRequest.class))),
-            responses = {
-                    @ApiResponse(
-                            responseCode = "201",
-                            description = "모임 개설 성공",
-                            content = @Content(schema = @Schema(implementation = MeetingSaveResponse.class))
-                    )
-            }
-    )
-    @ErrorCode400
-    @ErrorCode401
-    @ErrorCode500
-    ResponseEntity<MeetingSaveResponse> save(
-            @Parameter(hidden = true) Member member,
-            MeetingSaveRequest meetingSaveRequest
-    );
 
     @Operation(
             summary = "초대코드 유효성 검사",

--- a/backend/src/main/java/com/ody/meeting/dto/response/MeetingWithMatesResponse.java
+++ b/backend/src/main/java/com/ody/meeting/dto/response/MeetingWithMatesResponse.java
@@ -1,0 +1,57 @@
+package com.ody.meeting.dto.response;
+
+import com.ody.mate.domain.Mate;
+import com.ody.meeting.domain.Meeting;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record MeetingWithMatesResponse(
+
+        @Schema(description = "약속 ID", example = "1")
+        Long id,
+
+        @Schema(description = "약속 이름", example = "우테코 16조")
+        String name,
+
+        @Schema(description = "약속 날짜", type = "string", example = "2024-07-15")
+        LocalDate date,
+
+        @Schema(description = "약속 시간", type = "string", example = "14:00")
+        LocalTime time,
+
+        @Schema(description = "도착지 주소", example = "서울 송파구 올림픽로35다길 42")
+        String targetAddress,
+
+        @Schema(description = "도착지 위도", example = "37.515298")
+        String targetLatitude,
+
+        @Schema(description = "도착지 경도", example = "127.103113")
+        String targetLongitude,
+
+        @Schema(description = "참여자 인원 수", example = "1")
+        int mateCount,
+
+        @Schema(description = "참여자 닉네임 목록", example = "[{\"nickname\": \"오디\"}]")
+        List<MateResponse> mates,
+
+        @Schema(description = "초대코드", example = "초대코드")
+        String inviteCode
+) {
+
+    public static MeetingWithMatesResponse of(Meeting meeting, List<Mate> mates) {
+        return new MeetingWithMatesResponse(
+                meeting.getId(),
+                meeting.getName(),
+                meeting.getDate(),
+                meeting.getTime().withNano(0),
+                meeting.getTarget().getAddress(),
+                meeting.getTarget().getLatitude(),
+                meeting.getTarget().getLongitude(),
+                mates.size(),
+                MateResponse.from(mates),
+                meeting.getInviteCode()
+        );
+    }
+}

--- a/backend/src/main/java/com/ody/meeting/service/MeetingService.java
+++ b/backend/src/main/java/com/ody/meeting/service/MeetingService.java
@@ -5,11 +5,16 @@ import com.ody.mate.dto.request.MateSaveRequest;
 import com.ody.mate.service.MateService;
 import com.ody.meeting.domain.Meeting;
 import com.ody.meeting.dto.request.MeetingSaveRequest;
+import com.ody.meeting.dto.response.MateResponse;
 import com.ody.meeting.dto.response.MeetingSaveResponse;
 import com.ody.meeting.dto.response.MeetingSaveResponses;
+import com.ody.meeting.dto.response.MeetingWithMatesResponse;
 import com.ody.meeting.repository.MeetingRepository;
 import com.ody.member.domain.Member;
 import com.ody.util.InviteCodeGenerator;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -66,5 +71,23 @@ public class MeetingService {
         return meetingRepository.findAllMeetingsByMember(member).stream()
                 .map(mateService::findAllByMeetingId)
                 .collect(Collectors.collectingAndThen(Collectors.toList(), MeetingSaveResponses::new));
+    }
+
+    public MeetingWithMatesResponse findMeetingWithMates(Member member, Long meetingId) {
+        return new MeetingWithMatesResponse(
+                1L,
+                "우테코 16조",
+                LocalDate.parse("2024-07-15"),
+                LocalTime.parse("14:00"),
+                "서울 송파구 올림픽로35다길 42",
+                "37.515298",
+                "127.103113",
+                2,
+                List.of(
+                        new MateResponse("오디"),
+                        new MateResponse("제리")
+                ),
+                "초대코드"
+        );
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #233 


<br>

# 🗣️ 리뷰 요구사항
임의로 수정한 부분이 있습니다. 리뷰하실 때 의견 부탁드립니다!

### 1. response - `모임장 닉네임(nickname)` 필드 미구현
이유:
- 노션 API response 표에는 모임장 닉네임 필드가 있는데, 예시에는 없었습니다.
- meeting 테이블 내 모임장 관련 정보를 저장하지 않습니다.(현재 테이블 구조 상 조회할 수 없음)

### 2. 404 Error Code 추가
이유:
- 잘못된 meetingId을 요청할 수 있습니다. 노션 API에 404 에러를 추가했습니다.


