### PR TITLE
docs: 약속 참여 API 문서화

### DIFF
--- a/backend/src/main/java/com/ody/mate/controller/MateController.java
+++ b/backend/src/main/java/com/ody/mate/controller/MateController.java
@@ -19,7 +19,7 @@ public class MateController implements MateControllerSwagger {
     private final MeetingService meetingService;
 
     @Override
-    @PostMapping("/mates")
+    @PostMapping("/v1/mates")
     public ResponseEntity<MeetingSaveResponse> save(
             @AuthMember Member member,
             @RequestBody MateSaveRequest mateSaveRequest

--- a/backend/src/main/java/com/ody/mate/controller/MateController.java
+++ b/backend/src/main/java/com/ody/mate/controller/MateController.java
@@ -18,9 +18,19 @@ public class MateController implements MateControllerSwagger {
 
     private final MeetingService meetingService;
 
+    @PostMapping("/mates")
+    public ResponseEntity<MeetingSaveResponse> save(
+            @AuthMember Member member,
+            @RequestBody MateSaveRequest mateSaveRequest
+    ) {
+        MeetingSaveResponse meetingSaveResponse = meetingService.findAndSendNotifications(mateSaveRequest, member);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(meetingSaveResponse);
+    }
+
     @Override
     @PostMapping("/v1/mates")
-    public ResponseEntity<MeetingSaveResponse> save(
+    public ResponseEntity<MeetingSaveResponse> saveV1(
             @AuthMember Member member,
             @RequestBody MateSaveRequest mateSaveRequest
     ) {

--- a/backend/src/main/java/com/ody/mate/controller/MateControllerSwagger.java
+++ b/backend/src/main/java/com/ody/mate/controller/MateControllerSwagger.java
@@ -36,5 +36,5 @@ public interface MateControllerSwagger {
     @ErrorCode401
     @ErrorCode404(description = "유효하지 않은 초대코드")
     @ErrorCode500
-    ResponseEntity<MeetingSaveResponse> save(@Parameter(hidden = true) Member member, MateSaveRequest mateSaveRequest);
+    ResponseEntity<MeetingSaveResponse> saveV1(@Parameter(hidden = true) Member member, MateSaveRequest mateSaveRequest);
 }

--- a/backend/src/main/java/com/ody/mate/controller/MateControllerSwagger.java
+++ b/backend/src/main/java/com/ody/mate/controller/MateControllerSwagger.java
@@ -5,6 +5,7 @@ import com.ody.meeting.dto.response.MeetingSaveResponse;
 import com.ody.member.domain.Member;
 import com.ody.swagger.annotation.ErrorCode400;
 import com.ody.swagger.annotation.ErrorCode401;
+import com.ody.swagger.annotation.ErrorCode404;
 import com.ody.swagger.annotation.ErrorCode500;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,7 +15,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Mate API")
@@ -29,16 +29,12 @@ public interface MateControllerSwagger {
                             responseCode = "201",
                             description = "모임 참여 성공",
                             content = @Content(schema = @Schema(implementation = MeetingSaveResponse.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "유효하지 않은 초대코드",
-                            content = @Content(schema = @Schema(implementation = ProblemDetail.class))
                     )
             }
     )
     @ErrorCode400
     @ErrorCode401
+    @ErrorCode404(description = "유효하지 않은 초대코드")
     @ErrorCode500
     ResponseEntity<MeetingSaveResponse> save(@Parameter(hidden = true) Member member, MateSaveRequest mateSaveRequest);
 }

--- a/backend/src/main/java/com/ody/mate/dto/request/MateSaveRequest.java
+++ b/backend/src/main/java/com/ody/mate/dto/request/MateSaveRequest.java
@@ -9,10 +9,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MateSaveRequest(
 
-        @Schema(description = "초대코드", example = "초대코드")
+        @Schema(description = "초대코드", example = "inviteCodeinviteCode")
         String inviteCode,
 
-        @Schema(description = "참여자 닉네임", example = "제리")
+        @Schema(description = "참여자 닉네임", example = "오디")
         String nickname,
 
         @Schema(description = "출발지 주소", example = "서울 강남구 테헤란로 411")

--- a/backend/src/main/java/com/ody/meeting/dto/response/MateResponse.java
+++ b/backend/src/main/java/com/ody/meeting/dto/response/MateResponse.java
@@ -1,9 +1,14 @@
 package com.ody.meeting.dto.response;
 
 import com.ody.mate.domain.Mate;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record MateResponse(String nickname) {
+public record MateResponse(
+
+        @Schema(description = "참여자 닉네임", example = "오디")
+        String nickname
+) {
 
     public static List<MateResponse> from(List<Mate> mates) {
         return mates.stream()

--- a/backend/src/main/java/com/ody/meeting/dto/response/MeetingSaveResponse.java
+++ b/backend/src/main/java/com/ody/meeting/dto/response/MeetingSaveResponse.java
@@ -2,6 +2,7 @@ package com.ody.meeting.dto.response;
 
 import com.ody.mate.domain.Mate;
 import com.ody.meeting.domain.Meeting;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -33,7 +34,7 @@ public record MeetingSaveResponse(
         @Schema(description = "모임 인원 수", example = "1")
         int mateCount,
 
-        @Schema(description = "모임원 닉네임 목록", example = "[{\"nickname\": \"오디\"}]")
+        @ArraySchema(schema = @Schema(description = "참여자 모임 리스트", implementation = MateResponse.class))
         List<MateResponse> mates,
 
         @Schema(description = "초대코드", example = "초대코드")

--- a/backend/src/main/java/com/ody/swagger/annotation/ErrorCode404.java
+++ b/backend/src/main/java/com/ody/swagger/annotation/ErrorCode404.java
@@ -1,0 +1,21 @@
+package com.ody.swagger.annotation;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.ProblemDetail;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+        responseCode = "404",
+        content = @Content(schema = @Schema(implementation = ProblemDetail.class))
+)
+public @interface ErrorCode404 {
+
+    String description();
+}

--- a/backend/src/main/java/com/ody/swagger/annotation/ErrorCode404.java
+++ b/backend/src/main/java/com/ody/swagger/annotation/ErrorCode404.java
@@ -7,6 +7,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.http.ProblemDetail;
 
 @Target(ElementType.METHOD)
@@ -17,5 +18,6 @@ import org.springframework.http.ProblemDetail;
 )
 public @interface ErrorCode404 {
 
+    @AliasFor(annotation = ApiResponse.class, attribute = "description")
     String description();
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #231 


<br>

# 📝 작업 내용
- 404에러도 커스텀 어노테이션으로 description 옵션만 변경하여 에러 메세지가 다르게 표시되도록 적용
- /v1/mates API 문서화

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
- /mates 요청 메서드는 살리되 문서에선 헷갈릴 여지가 충분할것 같아 추가하지않았습니다. /mates가 지원중단으로 표시되어 있는데 지원 중단인 메서드들은 기존 컨트롤러에서도 제거하는게 어떠신가요?

<br>

- 404에러도 커스텀 어노테이션을 추가해 문서 작업을 할 때 404에러도 해당 커스텀 에러로 나머지 커스텀 에러와 일관되게 간편히 처리되도록 하면 좋을 것 같아요

<br>

- 응답 DTO로는 `MateSaveResponse`가 응답되는게 적절하다고 생각한는데 현재 노션에서 수정된 v1 API 문서상에 있는 응답 데이터가 `MeetingSaveResponse`와 동일하네요. 
<img width="452" alt="image" src="https://github.com/user-attachments/assets/c0ed5d8e-4ecb-4f1b-a6ab-9b907a54d2f6">
<br>
현재 개설하고 참여해 로그 화면을 보는 흐름이
/v1/meetings -> /v1/mates -> /meetings/{meetingId}/noti-log + /v1/meetings/{meetingId} 요청 순이 되는 것 같은데
맞나요 ?
맞다면 특히 mateCount와 mates 필드가 있는 의미가 없는 것 같아요
이부분 안드측과 얘기 후에 변경하면 좋을 것 같습니다