### PR TITLE
fix: 시간 데이터 초 제거 후 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/ody/mate/dto/response/MateSaveResponse.java
+++ b/backend/src/main/java/com/ody/mate/dto/response/MateSaveResponse.java
@@ -1,5 +1,6 @@
 package com.ody.mate.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.ody.mate.domain.Mate;
 import com.ody.meeting.domain.Meeting;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,6 +19,7 @@ public record MateSaveResponse(
         LocalDate date,
 
         @Schema(description = "약속 시간", type = "string", example = "14:00")
+        @JsonFormat(pattern = "HH:mm")
         LocalTime time,
 
         @Schema(description = "도착지 주소", example = "서울 송파구 올림픽로35다길 42")

--- a/backend/src/main/java/com/ody/meeting/dto/response/MeetingSaveResponse.java
+++ b/backend/src/main/java/com/ody/meeting/dto/response/MeetingSaveResponse.java
@@ -1,5 +1,6 @@
 package com.ody.meeting.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.ody.mate.domain.Mate;
 import com.ody.mate.dto.response.MateResponse;
 import com.ody.meeting.domain.Meeting;
@@ -21,6 +22,7 @@ public record MeetingSaveResponse(
         LocalDate date,
 
         @Schema(description = "모임 시간", type = "string", example = "14:00")
+        @JsonFormat(pattern = "HH:mm")
         LocalTime time,
 
         @Schema(description = "도착지 주소", example = "서울 송파구 올림픽로35다길 42")

--- a/backend/src/main/java/com/ody/meeting/dto/response/MeetingSaveResponseV1.java
+++ b/backend/src/main/java/com/ody/meeting/dto/response/MeetingSaveResponseV1.java
@@ -1,5 +1,6 @@
 package com.ody.meeting.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.ody.meeting.domain.Meeting;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
@@ -17,6 +18,7 @@ public record MeetingSaveResponseV1(
         LocalDate date,
 
         @Schema(description = "모임 시간", type = "string", example = "14:00")
+        @JsonFormat(pattern = "HH:mm")
         LocalTime time,
 
         @Schema(description = "도착지 주소", example = "서울 송파구 올림픽로35다길 42")

--- a/backend/src/main/java/com/ody/meeting/dto/response/MeetingWithMatesResponse.java
+++ b/backend/src/main/java/com/ody/meeting/dto/response/MeetingWithMatesResponse.java
@@ -1,5 +1,6 @@
 package com.ody.meeting.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.ody.mate.domain.Mate;
 import com.ody.mate.dto.response.MateResponse;
 import com.ody.meeting.domain.Meeting;
@@ -21,6 +22,7 @@ public record MeetingWithMatesResponse(
         LocalDate date,
 
         @Schema(description = "약속 시간", type = "string", example = "14:00")
+        @JsonFormat(pattern = "HH:mm")
         LocalTime time,
 
         @Schema(description = "도착지 주소", example = "서울 송파구 올림픽로35다길 42")


### PR DESCRIPTION
# 🚩 연관 이슈 
close #269 


<br>

# 📝 작업 내용
모든 API에 대한 호출 데이터의 시간 데이터가 초 제거 후 반환하도록 수정

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
