### PR TITLE
feat: 내 약속 목록 조회 시 현재 이후 약속만 조회

### DIFF
--- a/backend/src/main/java/com/ody/meeting/domain/Meeting.java
+++ b/backend/src/main/java/com/ody/meeting/domain/Meeting.java
@@ -55,6 +55,6 @@ public class Meeting {
     public boolean isWithinPast24HoursOrLater() {
         LocalDateTime dateTime = LocalDateTime.of(date, time);
         LocalDateTime standard = LocalDateTime.now().minusHours(24).withSecond(0);
-        return dateTime.isEqual(standard) || dateTime.isAfter(standard);
+        return standard.isBefore(dateTime);
     }
 }

--- a/backend/src/main/java/com/ody/meeting/domain/Meeting.java
+++ b/backend/src/main/java/com/ody/meeting/domain/Meeting.java
@@ -54,7 +54,7 @@ public class Meeting {
 
     public boolean isWithinPast24HoursOrLater() {
         LocalDateTime dateTime = LocalDateTime.of(date, time);
-        LocalDateTime standard = LocalDateTime.now().minusHours(24);
+        LocalDateTime standard = LocalDateTime.now().minusHours(24).withSecond(0);
         return dateTime.isEqual(standard) || dateTime.isAfter(standard);
     }
 }

--- a/backend/src/main/java/com/ody/meeting/domain/Meeting.java
+++ b/backend/src/main/java/com/ody/meeting/domain/Meeting.java
@@ -51,4 +51,10 @@ public class Meeting {
     public LocalDateTime getMeetingTime() {
         return LocalDateTime.of(date, time).withSecond(0).withNano(0);
     }
+
+    public boolean isWithinPast24HoursOrLater() {
+        LocalDateTime dateTime = LocalDateTime.of(date, time);
+        LocalDateTime standard = LocalDateTime.now().minusHours(24);
+        return dateTime.isEqual(standard) || dateTime.isAfter(standard);
+    }
 }

--- a/backend/src/main/java/com/ody/meeting/service/MeetingService.java
+++ b/backend/src/main/java/com/ody/meeting/service/MeetingService.java
@@ -62,6 +62,7 @@ public class MeetingService {
     public MeetingFindByMemberResponses findAllByMember(Member member) {
         return meetingRepository.findAllByMemberId(member.getId())
                 .stream()
+                .filter(Meeting::isWithinPast24HoursOrLater)
                 .map(meeting -> makeMeetingFindByMemberResponse(member, meeting))
                 .sorted(Comparator.comparing(MeetingFindByMemberResponse::date)
                         .thenComparing(MeetingFindByMemberResponse::time))

--- a/backend/src/test/java/com/ody/common/Fixture.java
+++ b/backend/src/test/java/com/ody/common/Fixture.java
@@ -61,6 +61,30 @@ public class Fixture {
             "초대코드"
     );
 
+    public static Meeting MEETING_24_HOURS_AGO = new Meeting(
+            "약속",
+            LocalDate.now().minusDays(1),
+            LocalTime.now(),
+            TARGET_LOCATION,
+            "초대코드"
+    );
+
+    public static Meeting MEETING_24_HOURS_1_MINUTE_AGO = new Meeting(
+            "약속",
+            LocalDate.now().minusDays(1),
+            LocalTime.now().minusMinutes(1),
+            TARGET_LOCATION,
+            "초대코드"
+    );
+
+    public static final Meeting MEETING_23_HOURS_59_MINUTES_AGO = new Meeting(
+            "약속",
+            LocalDate.now().minusDays(1),
+            LocalTime.now().plusMinutes(1),
+            TARGET_LOCATION,
+            "초대코드"
+    );
+
     public static Member MEMBER1 = new Member(new DeviceToken("Bearer device-token=testToken1"));
     public static Member MEMBER2 = new Member(new DeviceToken("Bearer device-token=testToken2"));
     public static Member MEMBER3 = new Member(new DeviceToken("Bearer device-token=testToken3"));

--- a/backend/src/test/java/com/ody/common/Fixture.java
+++ b/backend/src/test/java/com/ody/common/Fixture.java
@@ -61,30 +61,6 @@ public class Fixture {
             "초대코드"
     );
 
-    public static Meeting MEETING_24_HOURS_AGO = new Meeting(
-            "약속",
-            LocalDate.now().minusDays(1),
-            LocalTime.now(),
-            TARGET_LOCATION,
-            "초대코드"
-    );
-
-    public static Meeting MEETING_24_HOURS_1_MINUTE_AGO = new Meeting(
-            "약속",
-            LocalDate.now().minusDays(1),
-            LocalTime.now().minusMinutes(1),
-            TARGET_LOCATION,
-            "초대코드"
-    );
-
-    public static final Meeting MEETING_23_HOURS_59_MINUTES_AGO = new Meeting(
-            "약속",
-            LocalDate.now().minusDays(1),
-            LocalTime.now().plusMinutes(1),
-            TARGET_LOCATION,
-            "초대코드"
-    );
-
     public static Member MEMBER1 = new Member(new DeviceToken("Bearer device-token=testToken1"));
     public static Member MEMBER2 = new Member(new DeviceToken("Bearer device-token=testToken2"));
     public static Member MEMBER3 = new Member(new DeviceToken("Bearer device-token=testToken3"));

--- a/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
@@ -75,7 +75,7 @@ class MeetingServiceTest extends BaseServiceTest {
         );
     }
 
-    @DisplayName("내 약속 목록 조회 시 약속 시간이 현재 시간으로부터 24시간 이내인 약속부터 미래의 약속까지만 조회된다.")
+    @DisplayName("내 약속 목록 조회 시 약속 시간이 현재 시간으로부터 24시간 포함 이내인 약속부터 미래의 약속까지만 조회된다.")
     @Test
     void findAllByMemberFilterTime() {
         Member member = memberRepository.save(Fixture.MEMBER1);

--- a/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
@@ -76,7 +76,7 @@ class MeetingServiceTest extends BaseServiceTest {
     @DisplayName("내 약속 목록 조회 시 약속 시간이 현재 시간으로부터 24시간 이내인 약속부터 미래의 약속까지만 조회된다.")
     @Test
     void findAllByMemberFilterTime() {
-        Member member = memberRepository.save(new Member(new DeviceToken("Bearer device-token=member-dt")));
+        Member member = memberRepository.save(Fixture.MEMBER1);
 
         Meeting meeting24Hours1MinuteAgo = meetingRepository.save(Fixture.MEETING_24_HOURS_1_MINUTE_AGO);
         Meeting meeting24HoursAgo = meetingRepository.save(Fixture.MEETING_24_HOURS_AGO);
@@ -98,7 +98,7 @@ class MeetingServiceTest extends BaseServiceTest {
                 .map(MeetingFindByMemberResponse::id)
                 .toList();
 
-        assertThat(meetingIds).containsExactly(meeting23Hours59MinutesAgo.getId());
+        assertThat(meetingIds).containsExactly(meeting24HoursAgo.getId(), meeting23Hours59MinutesAgo.getId());
     }
 
     @DisplayName("약속 저장 및 초대 코드 갱신에 성공한다")

--- a/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
@@ -21,6 +21,8 @@ import com.ody.member.domain.DeviceToken;
 import com.ody.member.domain.Member;
 import com.ody.member.repository.MemberRepository;
 import com.ody.util.InviteCodeGenerator;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -78,9 +80,27 @@ class MeetingServiceTest extends BaseServiceTest {
     void findAllByMemberFilterTime() {
         Member member = memberRepository.save(Fixture.MEMBER1);
 
-        Meeting meeting24Hours1MinuteAgo = meetingRepository.save(Fixture.MEETING_24_HOURS_1_MINUTE_AGO);
-        Meeting meeting24HoursAgo = meetingRepository.save(Fixture.MEETING_24_HOURS_AGO);
-        Meeting meeting23Hours59MinutesAgo = meetingRepository.save(Fixture.MEETING_23_HOURS_59_MINUTES_AGO);
+        Meeting meeting24Hours1MinuteAgo = meetingRepository.save(new Meeting(
+                "약속",
+                LocalDate.now().minusDays(1),
+                LocalTime.now().minusMinutes(1),
+                Fixture.TARGET_LOCATION,
+                "초대코드"
+        ));
+        Meeting meeting24HoursAgo = meetingRepository.save(new Meeting(
+                "약속",
+                LocalDate.now().minusDays(1),
+                LocalTime.now(),
+                Fixture.TARGET_LOCATION,
+                "초대코드"
+        ));
+        Meeting meeting23Hours59MinutesAgo = meetingRepository.save(new Meeting(
+                "약속",
+                LocalDate.now().minusDays(1),
+                LocalTime.now().plusMinutes(1),
+                Fixture.TARGET_LOCATION,
+                "초대코드"
+        ));
 
         mateRepository.save(
                 new Mate(meeting24HoursAgo, member, new Nickname("제리1"), Fixture.ORIGIN_LOCATION, 10L)

--- a/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
@@ -22,6 +22,7 @@ import com.ody.member.domain.Member;
 import com.ody.member.repository.MemberRepository;
 import com.ody.util.InviteCodeGenerator;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -80,24 +81,26 @@ class MeetingServiceTest extends BaseServiceTest {
     void findAllByMemberFilterTime() {
         Member member = memberRepository.save(Fixture.MEMBER1);
 
+        LocalDateTime now = LocalDateTime.now();
+
         Meeting meeting24Hours1MinuteAgo = meetingRepository.save(new Meeting(
                 "약속",
-                LocalDate.now().minusDays(1),
-                LocalTime.now().minusMinutes(1),
+                now.toLocalDate().minusDays(1),
+                now.toLocalTime().minusMinutes(1),
                 Fixture.TARGET_LOCATION,
                 "초대코드"
         ));
         Meeting meeting24HoursAgo = meetingRepository.save(new Meeting(
                 "약속",
-                LocalDate.now().minusDays(1),
-                LocalTime.now(),
+                now.toLocalDate().minusDays(1),
+                now.toLocalTime(),
                 Fixture.TARGET_LOCATION,
                 "초대코드"
         ));
         Meeting meeting23Hours59MinutesAgo = meetingRepository.save(new Meeting(
                 "약속",
-                LocalDate.now().minusDays(1),
-                LocalTime.now().plusMinutes(1),
+                now.toLocalDate().minusDays(1),
+                now.toLocalTime().plusMinutes(1),
                 Fixture.TARGET_LOCATION,
                 "초대코드"
         ));


### PR DESCRIPTION
# 🚩 연관 이슈 
close #289 


<br>

# 📝 작업 내용
약속 시간이 현재 시간으로부터 24시간 이내인 약속부터 미래의 약속까지만 조회 가능하도록 필터링했습니다

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
