### PR TITLE
feat: 현황 화면 툴바 리스너 등록

### DIFF
--- a/android/app/src/main/java/com/woowacourse/ody/presentation/room/etadashboard/EtaDashboardActivity.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/room/etadashboard/EtaDashboardActivity.kt
@@ -1,5 +1,7 @@
 package com.woowacourse.ody.presentation.room.etadashboard
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.graphics.Point
@@ -11,16 +13,24 @@ import android.view.ViewGroup
 import android.widget.PopupWindow
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.woowacourse.ody.R
 import com.woowacourse.ody.databinding.ActivityEtaDashboardBinding
 import com.woowacourse.ody.databinding.LayoutMissingTooltipBinding
 import com.woowacourse.ody.presentation.common.binding.BindingActivity
+import com.woowacourse.ody.presentation.common.listener.BackListener
 import com.woowacourse.ody.presentation.room.etadashboard.adapter.MateEtasAdapter
 import com.woowacourse.ody.presentation.room.etadashboard.listener.MissingToolTipListener
+import com.woowacourse.ody.presentation.room.log.listener.CopyInviteCodeListener
+import com.woowacourse.ody.presentation.room.log.listener.ShareListener
 
 class EtaDashboardActivity :
     BindingActivity<ActivityEtaDashboardBinding>(R.layout.activity_eta_dashboard),
-    MissingToolTipListener {
+    MissingToolTipListener,
+    CopyInviteCodeListener,
+    ShareListener,
+    BackListener {
     private val viewModel: EtaDashboardViewModel by viewModels<EtaDashboardViewModel> {
         EtaDashboardViewModelFactory(
             meetingId = intent.getLongExtra(MEETING_ID_KEY, MEETING_ID_DEFAULT_VALUE),
@@ -28,11 +38,14 @@ class EtaDashboardActivity :
         )
     }
     private val adapter: MateEtasAdapter by lazy { MateEtasAdapter(this) }
+    private val bottomSheetLayout by lazy { findViewById<ConstraintLayout>(R.id.cl_bottom_sheet) }
+    private lateinit var bottomSheetBehavior: BottomSheetBehavior<ConstraintLayout>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initializeListAdapter()
         initializeObserve()
+        initializePersistentBottomSheet()
     }
 
     private fun initializeListAdapter() {
@@ -40,12 +53,20 @@ class EtaDashboardActivity :
     }
 
     override fun initializeBinding() {
+        binding.backListener = this
+        binding.shareListener = this
+        binding.copyInviteCodeListener = this
+        binding.title = intent.getStringExtra(MEETING_TITLE_KEY)
     }
 
     private fun initializeObserve() {
         viewModel.mateEtaUiModels.observe(this) {
             adapter.submitList(it)
         }
+    }
+
+    private fun initializePersistentBottomSheet() {
+        bottomSheetBehavior = BottomSheetBehavior.from(bottomSheetLayout)
     }
 
     override fun onClickMissingToolTipListener(
@@ -84,16 +105,41 @@ class EtaDashboardActivity :
         popupWindow.showAtLocation(window.decorView, Gravity.NO_GRAVITY, adjustedX, adjustedY)
     }
 
+    override fun onShare() {
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+    }
+
+    override fun onCopyInviteCode() {
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+        val inviteCode = intent.getStringExtra(INVITE_CODE_KEY) ?: return
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = ClipData.newPlainText(INVITE_CODE_LABEL, inviteCode)
+        clipboard.setPrimaryClip(clip)
+    }
+
+    override fun onBack() {
+        finish()
+    }
+
     companion object {
         private const val MEETING_ID_KEY = "meeting_id"
         private const val MEETING_ID_DEFAULT_VALUE = -1L
 
+        private const val INVITE_CODE_KEY = "invite_code"
+        private const val INVITE_CODE_LABEL = "inviteCode"
+
+        private const val MEETING_TITLE_KEY = "meeting_title"
+
         fun getIntent(
             context: Context,
             meetingId: Long,
+            inviteCode: String,
+            title: String,
         ): Intent {
             return Intent(context, EtaDashboardActivity::class.java).apply {
                 putExtra(MEETING_ID_KEY, meetingId)
+                putExtra(INVITE_CODE_KEY, inviteCode)
+                putExtra(MEETING_TITLE_KEY, title)
             }
         }
     }

--- a/android/app/src/main/java/com/woowacourse/ody/presentation/room/log/NotificationLogActivity.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/room/log/NotificationLogActivity.kt
@@ -46,7 +46,14 @@ class NotificationLogActivity :
         initializeObserve()
         initializePersistentBottomSheet()
         binding.btnOdy.setOnClickListener {
-            startActivity(EtaDashboardActivity.getIntent(this, getMeetingId()))
+            val intent =
+                EtaDashboardActivity.getIntent(
+                    this,
+                    getMeetingId(),
+                    viewModel.meeting.value?.inviteCode ?: return@setOnClickListener,
+                    viewModel.meeting.value?.name ?: return@setOnClickListener,
+                )
+            startActivity(intent)
         }
     }
 

--- a/android/app/src/main/res/layout/activity_eta_dashboard.xml
+++ b/android/app/src/main/res/layout/activity_eta_dashboard.xml
@@ -38,7 +38,8 @@
                 app:backListener="@{backListener}"
                 app:layout_constraintBottom_toTopOf="@+id/rv_dashboard"
                 app:layout_constraintTop_toTopOf="parent"
-                app:shareListener="@{shareListener}" />
+                app:shareListener="@{shareListener}"
+                app:title="@{title}" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_dashboard"

--- a/android/app/src/main/res/layout/activity_eta_dashboard.xml
+++ b/android/app/src/main/res/layout/activity_eta_dashboard.xml
@@ -5,36 +5,60 @@
 
     <data>
 
+        <variable
+            name="title"
+            type="java.lang.String" />
+
+        <variable
+            name="shareListener"
+            type="com.woowacourse.ody.presentation.room.log.listener.ShareListener" />
+
+        <variable
+            name="copyInviteCodeListener"
+            type="com.woowacourse.ody.presentation.room.log.listener.CopyInviteCodeListener" />
+
+        <variable
+            name="backListener"
+            type="com.woowacourse.ody.presentation.common.listener.BackListener" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <include
-            android:id="@+id/tb_dashboard"
-            layout="@layout/toolbar_meeting_room"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toTopOf="@+id/rv_dashboard"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:layout_height="match_parent">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_dashboard"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:clipToPadding="false"
-            android:paddingVertical="11dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tb_dashboard"
-            tools:listitem="@layout/item_eta_dashboard" />
+            <include
+                android:id="@+id/tb_dashboard"
+                layout="@layout/toolbar_meeting_room"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:backListener="@{backListener}"
+                app:layout_constraintBottom_toTopOf="@+id/rv_dashboard"
+                app:layout_constraintTop_toTopOf="parent"
+                app:shareListener="@{shareListener}" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_dashboard"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:clipToPadding="false"
+                android:paddingVertical="11dp"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tb_dashboard"
+                tools:listitem="@layout/item_eta_dashboard" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <include
             layout="@layout/bottom_sheet_code_copy"
-            android:visibility="gone" />
+            app:copyInviteCodeListener="@{copyInviteCodeListener}" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
 </layout>


### PR DESCRIPTION
# 🚩 연관 이슈 
close #295 

<br>

# 📝 작업 내용
- [x] 공유 버튼 클릭 시 초대 코드 복사 bottomDialog 
- [x] 뒤로가기 버튼 클릭 시 finish
- [x] 약속 이름이 보임

<br>

# 🏞️ 스크린샷 (선택)


https://github.com/user-attachments/assets/7b0f095e-c0c6-4c4e-99ca-c9d151087f82




<br>

# 🗣️ 리뷰 요구사항 (선택)
NotificationLog 화면의 툴바 코드와 유사합니다.
현재는 NotificationLog 화면의 툴바와 완전히 동일해서, NotificationLog 화면에서 Eta 화면으로 데이터를 전달하고 있습니다.
그런데 Intent로 데이터를 하나하나 전달하는 로직이 좀 번거롭게 느껴지네요.
동일한 툴바를 공유하는 `MeetingRoomActivity` 등을 만들어서 NotificationLog와 Eta 화면을 fragment로 보여주면 더 깔끔해질 것 같아요.
추후 이런 방식으로 리팩터링 해보면 어떨까요??????