### PR TITLE
fix: 행방불명상태의 소요시간 응답 오류 해결

### DIFF
--- a/backend/src/main/java/com/ody/eta/domain/Eta.java
+++ b/backend/src/main/java/com/ody/eta/domain/Eta.java
@@ -37,6 +37,7 @@ public class Eta {
 
     private boolean isArrived;
 
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
@@ -93,5 +94,16 @@ public class Eta {
     public void updateArrived() {
         this.isArrived = true;
         this.remainingMinutes = 0L;
+    }
+
+    @PrePersist
+    public void onPrePersist() {
+        this.createdAt = LocalDateTime.now().withSecond(0).withNano(0);
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    public void onPreUpdate() {
+        this.updatedAt = LocalDateTime.now().withSecond(0).withNano(0);
     }
 }

--- a/backend/src/main/java/com/ody/eta/domain/Eta.java
+++ b/backend/src/main/java/com/ody/eta/domain/Eta.java
@@ -8,8 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -43,7 +41,14 @@ public class Eta {
     private LocalDateTime updatedAt;
 
     public Eta(Mate mate, Long remainingMinutes) {
-        this(null, mate, remainingMinutes, false, LocalDateTime.now(), LocalDateTime.now());
+        this(
+                null,
+                mate,
+                remainingMinutes,
+                false,
+                LocalDateTime.now().withSecond(0).withNano(0),
+                LocalDateTime.now().withSecond(0).withNano(0)
+        );
     }
 
     public Eta(Mate mate, long remainingMinutes, LocalDateTime createdAt, LocalDateTime updatedAt) {
@@ -94,16 +99,5 @@ public class Eta {
     public void updateArrived() {
         this.isArrived = true;
         this.remainingMinutes = 0L;
-    }
-
-    @PrePersist
-    public void onPrePersist() {
-        this.createdAt = LocalDateTime.now().withSecond(0).withNano(0);
-        this.updatedAt = this.createdAt;
-    }
-
-    @PreUpdate
-    public void onPreUpdate() {
-        this.updatedAt = LocalDateTime.now().withSecond(0).withNano(0);
     }
 }

--- a/backend/src/main/java/com/ody/eta/dto/response/MateEtaResponse.java
+++ b/backend/src/main/java/com/ody/eta/dto/response/MateEtaResponse.java
@@ -17,7 +17,6 @@ public record MateEtaResponse(
         long durationMinutes
 ) {
     public static MateEtaResponse of(Eta eta, boolean isMissing, LocalDateTime meetingTime, LocalDateTime now) {
-
         return new MateEtaResponse(
                 eta.getMate().getNicknameValue(),
                 EtaStatus.from(eta, meetingTime, now, isMissing),

--- a/backend/src/test/java/com/ody/eta/domain/EtaTest.java
+++ b/backend/src/test/java/com/ody/eta/domain/EtaTest.java
@@ -19,7 +19,8 @@ class EtaTest {
         Meeting odyMeeting = Fixture.ODY_MEETING;
         Member member1 = Fixture.MEMBER1;
         Mate mate = new Mate(odyMeeting, member1, new Nickname("콜리"), Fixture.ORIGIN_LOCATION, 10L);
-        Eta eta = new Eta(mate, 1L);
+        LocalDateTime now = LocalDateTime.now().minusMinutes(1).withSecond(0).withNano(0);
+        Eta eta = new Eta(mate, 1L, now, now);
 
         eta.updateRemainingMinutes(5L);
 


### PR DESCRIPTION
# 🚩 연관 이슈 
close #294 


<br>

# 📝 작업 내용
- createAt 최초 저장 이후 변경 방지
- Missing 상태 일 시 -1 매직값이 반환되도록 추가
- EtaTest에서 isModified() 테스트 오류 수정

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
prePersist를 사용해서 LocalDateTime이 나노초가 제거되어 저장되도록 코드를 반영하려 했었는데
이 상황에서 Eta 도메인 테스트 작성시 데이터가 저장되어야지만 prePersist가 동작하는 문제가 있어
Eta 도메인 테스트가 Jpa에 의존적인 테스트가 되어 도메인 테스트임에도 불구하고 Bean들을 등록후 member, meeting, mate, eta들을 다 저장해서 테스트해야하는 문제가 있어 원래대로 롤백했어요

LocalDateTime 초를 제거하는 부분은 제리가 말했던데로 추후에 utill 클래스로 빼서 작업하면 좋을 듯한것 같습니다 🤔