### PR TITLE
fix: 로그 화면에서 값이 없는 화면이 나타나는 버그

### DIFF
--- a/android/app/src/main/java/com/woowacourse/ody/presentation/room/log/NotificationLogViewModel.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/room/log/NotificationLogViewModel.kt
@@ -19,7 +19,7 @@ class NotificationLogViewModel(
     private val notificationLogRepository: NotificationLogRepository,
     private val meetingRepository: MeetingRepository,
 ) : ViewModel() {
-    private val _meeting = MutableLiveData<MeetingDetailUiModel>()
+    private val _meeting = MutableLiveData(MeetingDetailUiModel())
     val meeting: LiveData<MeetingDetailUiModel> = _meeting
 
     private val _notificationLogs = MutableLiveData<List<NotificationLogUiModel>>()

--- a/android/app/src/main/java/com/woowacourse/ody/presentation/room/log/model/MeetingDetailUiModel.kt
+++ b/android/app/src/main/java/com/woowacourse/ody/presentation/room/log/model/MeetingDetailUiModel.kt
@@ -1,10 +1,10 @@
 package com.woowacourse.ody.presentation.room.log.model
 
 data class MeetingDetailUiModel(
-    val name: String,
-    val targetPosition: String,
-    val meetingTime: String,
-    val mates: List<String>,
-    val inviteCode: String,
-    val isEtaAccessible: Boolean,
+    val name: String = "-",
+    val targetPosition: String = "-",
+    val meetingTime: String = "-",
+    val mates: List<String> = listOf("-"),
+    val inviteCode: String = "-",
+    val isEtaAccessible: Boolean = false,
 )


### PR DESCRIPTION
# 🚩 연관 이슈 
close #330 


<br>

# 📝 작업 내용
- [x] 로그 화면에서 null이 잠깐 나타났다 사라지는 뷰 수정

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
추후에 로딩을 넣어야 합니다. 유저 입장에서 어색하긴 하네요.