### PR TITLE
design: 초대 코드 item과 모임 정보 칸과의 간격을 늘림

### DIFF
--- a/android/app/src/main/res/layout/item_invite_code_log.xml
+++ b/android/app/src/main/res/layout/item_invite_code_log.xml
@@ -19,7 +19,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="23dp"
+            android:layout_marginTop="26dp"
             android:text="@string/item_invite_code_top"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
# 🚩 연관 이슈 
close #331 

<br>

# 📝 작업 내용
- [x] 초대 코드 item과 모임 정보 칸과의 간격을 늘림

<br>

# 🏞️ 스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/5adf5725-0117-4409-bb44-5414b924afaa"  width="50%" height="50%"/>

<br>

# 🗣️ 리뷰 요구사항 (선택)
