### PR TITLE
fix: 로그 화면 닉네임들 길어지면 안보이는 버그 수정

### DIFF
--- a/android/app/src/main/res/layout/activity_notification_log.xml
+++ b/android/app/src/main/res/layout/activity_notification_log.xml
@@ -97,22 +97,32 @@
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="8dp"
                     android:src="@drawable/ic_person"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_meeting_people"
-                    app:layout_constraintEnd_toStartOf="@id/tv_meeting_people"
-                    app:layout_constraintTop_toTopOf="@id/tv_meeting_people" />
+                    app:layout_constraintBottom_toBottomOf="@id/hsv_meeting_people"
+                    app:layout_constraintEnd_toStartOf="@id/hsv_meeting_people"
+                    app:layout_constraintTop_toTopOf="@id/hsv_meeting_people" />
 
-                <TextView
-                    android:id="@+id/tv_meeting_people"
-                    style="@style/pretendard_regular_16"
-                    setMatesText="@{vm.meeting.mates}"
-                    android:layout_width="wrap_content"
+                <HorizontalScrollView
+                    android:id="@+id/hsv_meeting_people"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
+                    android:layout_marginEnd="30dp"
                     android:layout_marginBottom="14dp"
                     app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="@id/tv_meeting_date"
-                    app:layout_constraintTop_toBottomOf="@id/tv_meeting_position"
-                    tools:text="3명 / 올리브, 해음, 차람" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_meeting_position">
+
+                    <TextView
+                        android:id="@+id/tv_meeting_people"
+                        style="@style/pretendard_regular_16"
+                        setMatesText="@{vm.meeting.mates}"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        tools:text="3명 / 올리브, 해음, 차람" />
+
+                </HorizontalScrollView>
+
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.recyclerview.widget.RecyclerView
@@ -120,8 +130,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:layout_marginStart="18dp"
-                android:layout_marginEnd="18dp"
                 android:layout_marginTop="115dp"
+                android:layout_marginEnd="18dp"
                 app:itemAnimator="@{null}"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/android/app/src/main/res/layout/fragment_meeting_date.xml
+++ b/android/app/src/main/res/layout/fragment_meeting_date.xml
@@ -41,8 +41,8 @@
             android:id="@+id/dp_date"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="56dp"
             android:layout_marginHorizontal="@dimen/page_horizontal_margin"
+            android:layout_marginTop="56dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_meet" />

--- a/android/app/src/main/res/layout/item_notification_log.xml
+++ b/android/app/src/main/res/layout/item_notification_log.xml
@@ -30,8 +30,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="19dp"
-            android:textColor="@color/gray_350"
             android:text="@{log.created}"
+            android:textColor="@color/gray_350"
             app:layout_constraintStart_toStartOf="@id/tv_notification_log"
             app:layout_constraintTop_toBottomOf="@id/tv_notification_log"
             tools:text="2024-07-07 14:30" />


### PR DESCRIPTION
# 🚩 연관 이슈 
close #333 


<br>

# 📝 작업 내용
- [x] 로그화면 닉네임 길어지면 스크롤 되게 변경 

<br>

# 🏞️ 스크린샷 (선택)
[Screen_recording_20240810_133649.webm](https://github.com/user-attachments/assets/a6961642-d304-4b67-8223-8f4938065bfa)

<br>

# 🗣️ 리뷰 요구사항 (선택)
