### PR TITLE
fix: 동일한 topic을 구독하여 참여하지 않은 메이트의 알림 받음

### DIFF
--- a/backend/src/main/java/com/ody/meeting/domain/Meeting.java
+++ b/backend/src/main/java/com/ody/meeting/domain/Meeting.java
@@ -1,5 +1,7 @@
 package com.ody.meeting.domain;
 
+import com.ody.common.domain.BaseEntity;
+import com.ody.notification.domain.FcmTopic;
 import com.ody.util.TimeUtil;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -19,7 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-public class Meeting {
+public class Meeting extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -61,5 +63,9 @@ public class Meeting {
 
     public LocalDateTime getMeetingTime() {
         return TimeUtil.trimSecondsAndNanos(LocalDateTime.of(date, time));
+    }
+
+    public FcmTopic buildFcmTopic() {
+        return new FcmTopic(this);
     }
 }

--- a/backend/src/main/java/com/ody/meeting/domain/Meeting.java
+++ b/backend/src/main/java/com/ody/meeting/domain/Meeting.java
@@ -1,7 +1,6 @@
 package com.ody.meeting.domain;
 
 import com.ody.common.domain.BaseEntity;
-import com.ody.notification.domain.FcmTopic;
 import com.ody.util.TimeUtil;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -63,9 +62,5 @@ public class Meeting extends BaseEntity {
 
     public LocalDateTime getMeetingTime() {
         return TimeUtil.trimSecondsAndNanos(LocalDateTime.of(date, time));
-    }
-
-    public FcmTopic buildFcmTopic() {
-        return new FcmTopic(this);
     }
 }

--- a/backend/src/main/java/com/ody/meeting/domain/Meeting.java
+++ b/backend/src/main/java/com/ody/meeting/domain/Meeting.java
@@ -18,9 +18,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Meeting extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/com/ody/notification/domain/FcmTopic.java
+++ b/backend/src/main/java/com/ody/notification/domain/FcmTopic.java
@@ -8,12 +8,12 @@ public class FcmTopic {
 
     private String value;
 
-    public FcmTopic(String rawValue) {
-        this.value = rawValue.replace(":", "-");
-    }
-
     public FcmTopic(Meeting meeting) {
         this(build(meeting));
+    }
+    
+    public FcmTopic(String rawValue) {
+        this.value = rawValue.replace(":", "-");
     }
 
     private static String build(Meeting meeting) {

--- a/backend/src/main/java/com/ody/notification/domain/FcmTopic.java
+++ b/backend/src/main/java/com/ody/notification/domain/FcmTopic.java
@@ -1,0 +1,25 @@
+package com.ody.notification.domain;
+
+import com.ody.meeting.domain.Meeting;
+import lombok.Getter;
+
+@Getter
+public class FcmTopic {
+
+    private String value;
+
+    public FcmTopic(String rawValue) {
+        this.value = rawValue.replace(":", "-");
+    }
+
+    public FcmTopic(Meeting meeting) {
+        this(build(meeting));
+    }
+
+    private static String build(Meeting meeting) {
+        return new StringBuilder(meeting.getId().toString())
+                .append("_")
+                .append(meeting.getCreatedAt())
+                .toString();
+    }
+}

--- a/backend/src/main/java/com/ody/notification/domain/FcmTopic.java
+++ b/backend/src/main/java/com/ody/notification/domain/FcmTopic.java
@@ -17,9 +17,8 @@ public class FcmTopic {
     }
 
     private static String build(Meeting meeting) {
-        return new StringBuilder(meeting.getId().toString())
-                .append("_")
-                .append(meeting.getCreatedAt())
-                .toString();
+        return meeting.getId().toString()
+                + "_"
+                + meeting.getCreatedAt();
     }
 }

--- a/backend/src/main/java/com/ody/notification/dto/request/FcmSendRequest.java
+++ b/backend/src/main/java/com/ody/notification/dto/request/FcmSendRequest.java
@@ -1,12 +1,8 @@
 package com.ody.notification.dto.request;
 
-import com.ody.meeting.domain.Meeting;
 import com.ody.notification.domain.FcmTopic;
 import com.ody.notification.domain.Notification;
 
 public record FcmSendRequest(FcmTopic fcmTopic, Notification notification) {
 
-    public FcmSendRequest(Meeting meeting, Notification notification) {
-        this(meeting.buildFcmTopic(), notification);
-    }
 }

--- a/backend/src/main/java/com/ody/notification/dto/request/FcmSendRequest.java
+++ b/backend/src/main/java/com/ody/notification/dto/request/FcmSendRequest.java
@@ -1,11 +1,12 @@
 package com.ody.notification.dto.request;
 
 import com.ody.meeting.domain.Meeting;
+import com.ody.notification.domain.FcmTopic;
 import com.ody.notification.domain.Notification;
 
-public record FcmSendRequest(String topic, Notification notification) {
+public record FcmSendRequest(FcmTopic fcmTopic, Notification notification) {
 
     public FcmSendRequest(Meeting meeting, Notification notification) {
-        this(meeting.getId().toString(), notification);
+        this(meeting.buildFcmTopic(), notification);
     }
 }

--- a/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
+++ b/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
@@ -22,7 +22,7 @@ public class FcmPushSender {
         Message message = Message.builder()
                 .putData("type", notification.getType().toString())
                 .putData("nickname", notification.getMate().getNicknameValue())
-                .setTopic(fcmSendRequest.topic())
+                .setTopic(fcmSendRequest.fcmTopic().getValue())
                 .build();
         try {
             FirebaseMessaging.getInstance().send(message);

--- a/backend/src/main/java/com/ody/notification/service/FcmSubscriber.java
+++ b/backend/src/main/java/com/ody/notification/service/FcmSubscriber.java
@@ -1,10 +1,9 @@
 package com.ody.notification.service;
 
 import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.TopicManagementResponse;
 import com.ody.common.exception.OdyServerErrorException;
-import com.ody.meeting.domain.Meeting;
 import com.ody.member.domain.DeviceToken;
+import com.ody.notification.domain.FcmTopic;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,13 +12,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class FcmSubscriber {
 
-    public void subscribeTopic(Meeting meeting, DeviceToken deviceToken) {
+    public void subscribeTopic(FcmTopic fcmTopic, DeviceToken deviceToken) {
         try {
-            TopicManagementResponse topicManagementResponse = FirebaseMessaging.getInstance()
-                    .subscribeToTopic(List.of(deviceToken.getDeviceToken()), meeting.getId().toString());
-            log.info("모임 구독에 성공했습니다 {}", topicManagementResponse);
+            FirebaseMessaging.getInstance()
+                    .subscribeToTopic(List.of(deviceToken.getDeviceToken()), fcmTopic.getValue());
+            log.info("주제 구독에 성공했습니다. -- TOKEN = {}, TOPIC = {}", deviceToken.getDeviceToken(), fcmTopic.getValue());
         } catch (Exception exception) {
-            log.error(exception.getMessage());
+            log.error("주제 구독에 실패했습니다. -- {}", exception.getMessage());
             throw new OdyServerErrorException("모임 구독에 실패했습니다");
         }
     }

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -41,7 +41,7 @@ public class NotificationService {
             RouteTime routeTime
     ) {
         saveAndSendEntryNotification(meeting, mate);
-        fcmSubscriber.subscribeTopic(meeting, deviceToken);
+        fcmSubscriber.subscribeTopic(meeting.buildFcmTopic(), deviceToken);
         saveAndSendDepartureReminderNotification(meeting, mate, routeTime);
     }
 

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import com.ody.common.exception.OdyNotFoundException;
 import com.ody.mate.domain.Mate;
 import com.ody.meeting.domain.Meeting;
 import com.ody.member.domain.DeviceToken;
+import com.ody.notification.domain.FcmTopic;
 import com.ody.notification.domain.Notification;
 import com.ody.notification.dto.request.FcmSendRequest;
 import com.ody.notification.repository.NotificationRepository;
@@ -41,7 +42,7 @@ public class NotificationService {
             RouteTime routeTime
     ) {
         saveAndSendEntryNotification(meeting, mate);
-        fcmSubscriber.subscribeTopic(meeting.buildFcmTopic(), deviceToken);
+        fcmSubscriber.subscribeTopic(new FcmTopic(meeting), deviceToken);
         saveAndSendDepartureReminderNotification(meeting, mate, routeTime);
     }
 
@@ -66,7 +67,7 @@ public class NotificationService {
 
     private void saveAndSendNotification(Meeting meeting, Notification notification) {
         Notification savedNotification = notificationRepository.save(notification);
-        FcmSendRequest fcmSendRequest = new FcmSendRequest(meeting, savedNotification);
+        FcmSendRequest fcmSendRequest = new FcmSendRequest(new FcmTopic(meeting), savedNotification);
         scheduleNotification(fcmSendRequest);
     }
 

--- a/backend/src/test/java/com/ody/notification/service/FcmEventSchedulerTest.java
+++ b/backend/src/test/java/com/ody/notification/service/FcmEventSchedulerTest.java
@@ -13,6 +13,7 @@ import com.ody.meeting.domain.Meeting;
 import com.ody.meeting.repository.MeetingRepository;
 import com.ody.member.domain.Member;
 import com.ody.member.repository.MemberRepository;
+import com.ody.notification.domain.FcmTopic;
 import com.ody.notification.domain.Notification;
 import com.ody.notification.domain.NotificationStatus;
 import com.ody.notification.domain.NotificationType;
@@ -53,7 +54,7 @@ class FcmEventSchedulerTest extends BaseServiceTest {
                 sendAt,
                 NotificationStatus.PENDING
         ));
-        FcmSendRequest fcmSendRequest = new FcmSendRequest(meeting, notification);
+        FcmSendRequest fcmSendRequest = new FcmSendRequest(new FcmTopic(meeting), notification);
 
         // 비동기 작업을 동기화 시키기 위한 클래스
         // 파라미터 인자에 비동기 작업의 개수를 입력해준다.

--- a/backend/src/test/java/com/ody/notification/service/FcmEventSchedulerTest.java
+++ b/backend/src/test/java/com/ody/notification/service/FcmEventSchedulerTest.java
@@ -53,7 +53,7 @@ class FcmEventSchedulerTest extends BaseServiceTest {
                 sendAt,
                 NotificationStatus.PENDING
         ));
-        FcmSendRequest fcmSendRequest = new FcmSendRequest(meeting.getId().toString(), notification);
+        FcmSendRequest fcmSendRequest = new FcmSendRequest(meeting, notification);
 
         // 비동기 작업을 동기화 시키기 위한 클래스
         // 파라미터 인자에 비동기 작업의 개수를 입력해준다.


### PR DESCRIPTION
# 🚩 연관 이슈 
close #366


<br>

# 📝 작업 내용

아이디로 주제를 구독하는 방식을 유지하면서 <ins>약속 아이디를 uuid로 변경</ins>하는 것은 
- 초대코드 길이를 짧게 유지해야 한다는 조건을 만족할 수 없어 초대코드 생성 방안을 새로 마련해야 하므로 대안에서 제외했습니다

<br>

<ins>약속에 uuid 필드를 추가하고 이를 이용해 주제를 구독</ins>하는 것은
- 스키마 변경에 따라 감당해야 할 코드 수정이 지나치게 많아 대안에서 제외했습니다

<br>

<ins>약속 아이디, 약속 생성 시각을 인코딩</ins>해 inviteCode 필드에 저장하고, <ins>이를 초대코드, 주제 구독에 사용</ins>하는 것은
- 필드 추가의 부담이 없으나, 초대코드 길이를 짧게 유지해야 한다는 조건을 만족할 수 없어 대안에서 제외했습니다
- (참고) `1_2024-08-13T15:30:00.12345`이 `MV8yMDI0LTA4LTEzVDE1OjMwOjAwLjEyMzQ1Rd`로 인코딩됩니다
<br>

따라서 약속에 약속 생성 시각 필드를 추가하고 약속 아이디, 약속 생성 시각을 조합해 주제를 구독하는 방안을 택했습니다.
- 필드 추가가 있으나, `BaseEntity`를 사용함으로써 필드 추가에 따른 코드 수정이 발생하지 않습니다
- `{약속 아이디}_{약속 생성 시각}`을 주제로 사용하나, `:`은 주제에 포함될 수 없는 문자이므로 이를 `-`으로 대체했습니다

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
