### PR TITLE
feat: 약속 참여자 ETA 조회 시, 수도권 외 지역 예외처리

### DIFF
--- a/backend/src/main/java/com/ody/common/annotation/FutureOrPresentDateTime.java
+++ b/backend/src/main/java/com/ody/common/annotation/FutureOrPresentDateTime.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 
 @Documented
 @Constraint(validatedBy = FutureOrPresentDateTimeValidator.class)
-@Target({ElementType.TYPE})
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface FutureOrPresentDateTime {
 

--- a/backend/src/main/java/com/ody/common/annotation/SupportRegion.java
+++ b/backend/src/main/java/com/ody/common/annotation/SupportRegion.java
@@ -1,0 +1,27 @@
+package com.ody.common.annotation;
+
+import com.ody.common.validator.SupportRegionValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = SupportRegionValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SupportRegion {
+
+    String message() default "수도권 내 위경도 좌표만 가능합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    String latitudeFieldName();
+
+    String longitudeFieldName();
+}

--- a/backend/src/main/java/com/ody/common/annotation/SupportRegion.java
+++ b/backend/src/main/java/com/ody/common/annotation/SupportRegion.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 
 @Documented
 @Constraint(validatedBy = SupportRegionValidator.class)
-@Target({ElementType.TYPE})
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SupportRegion {
 

--- a/backend/src/main/java/com/ody/common/validator/SupportRegionValidator.java
+++ b/backend/src/main/java/com/ody/common/validator/SupportRegionValidator.java
@@ -27,11 +27,11 @@ public class SupportRegionValidator implements ConstraintValidator<SupportRegion
     public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
         try {
             Class<?> objectClass = object.getClass();
-            Method dateGetter = objectClass.getMethod(latitudeFieldName);
-            Method timeGetter = objectClass.getMethod(longitudeFieldName);
+            Method latitudeGetter = objectClass.getMethod(latitudeFieldName);
+            Method longitudeGetter = objectClass.getMethod(longitudeFieldName);
 
-            String latitude = (String) dateGetter.invoke(object);
-            String longitude = (String) timeGetter.invoke(object);
+            String latitude = (String) latitudeGetter.invoke(object);
+            String longitude = (String) longitudeGetter.invoke(object);
 
             return isInLatitudeRange(latitude) && isInLongitudeRange(longitude);
         } catch (Exception exception) {

--- a/backend/src/main/java/com/ody/common/validator/SupportRegionValidator.java
+++ b/backend/src/main/java/com/ody/common/validator/SupportRegionValidator.java
@@ -1,0 +1,51 @@
+package com.ody.common.validator;
+
+import com.ody.common.annotation.SupportRegion;
+import com.ody.common.exception.OdyServerErrorException;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+
+public class SupportRegionValidator implements ConstraintValidator<SupportRegion, Object> {
+
+    private static final BigDecimal MIN_LATITUDE = new BigDecimal("36.88");
+    private static final BigDecimal MAX_LATITUDE = new BigDecimal("38.3");
+    private static final BigDecimal MIN_LONGITUDE = new BigDecimal("125.6");
+    private static final BigDecimal MAX_LONGITUDE = new BigDecimal("127.9");
+
+    private String latitudeFieldName;
+    private String longitudeFieldName;
+
+    @Override
+    public void initialize(SupportRegion constraintAnnotation) {
+        latitudeFieldName = constraintAnnotation.latitudeFieldName();
+        longitudeFieldName = constraintAnnotation.longitudeFieldName();
+    }
+
+    @Override
+    public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
+        try {
+            Class<?> objectClass = object.getClass();
+            Method dateGetter = objectClass.getMethod(latitudeFieldName);
+            Method timeGetter = objectClass.getMethod(longitudeFieldName);
+
+            String latitude = (String) dateGetter.invoke(object);
+            String longitude = (String) timeGetter.invoke(object);
+
+            return isInLatitudeRange(latitude) && isInLongitudeRange(longitude);
+        } catch (Exception exception) {
+            throw new OdyServerErrorException(exception.getMessage());
+        }
+    }
+
+    private boolean isInLatitudeRange(String latitude) {
+        BigDecimal latitudeValue = new BigDecimal(latitude);
+        return MIN_LATITUDE.compareTo(latitudeValue) <= 0 && MAX_LATITUDE.compareTo(latitudeValue) >= 0;
+    }
+
+    private boolean isInLongitudeRange(String longitude) {
+        BigDecimal longitudeValue = new BigDecimal(longitude);
+        return MIN_LONGITUDE.compareTo(longitudeValue) <= 0 && MAX_LONGITUDE.compareTo(longitudeValue) >= 0;
+    }
+}

--- a/backend/src/main/java/com/ody/eta/dto/request/MateEtaRequest.java
+++ b/backend/src/main/java/com/ody/eta/dto/request/MateEtaRequest.java
@@ -1,8 +1,10 @@
 package com.ody.eta.dto.request;
 
+import com.ody.common.annotation.SupportRegion;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 
+@SupportRegion(latitudeFieldName = "currentLatitude", longitudeFieldName = "currentLongitude")
 public record MateEtaRequest(
 
         @Schema(description = "위치추적 불가 여부", example = "false")

--- a/backend/src/main/java/com/ody/mate/controller/MateController.java
+++ b/backend/src/main/java/com/ody/mate/controller/MateController.java
@@ -7,6 +7,7 @@ import com.ody.mate.dto.response.MateSaveResponse;
 import com.ody.meeting.dto.response.MeetingSaveResponse;
 import com.ody.meeting.service.MeetingService;
 import com.ody.member.domain.Member;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -49,7 +50,7 @@ public class MateController implements MateControllerSwagger {
     @PostMapping("/v1/mates")
     public ResponseEntity<MateSaveResponse> saveV1(
             @AuthMember Member member,
-            @RequestBody MateSaveRequest mateSaveRequest
+            @Valid @RequestBody MateSaveRequest mateSaveRequest
     ) {
         MateSaveResponse mateSaveResponse = meetingService.saveMateAndSendNotifications(mateSaveRequest, member);
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/backend/src/main/java/com/ody/mate/dto/request/MateSaveRequest.java
+++ b/backend/src/main/java/com/ody/mate/dto/request/MateSaveRequest.java
@@ -1,5 +1,6 @@
 package com.ody.mate.dto.request;
 
+import com.ody.common.annotation.SupportRegion;
 import com.ody.mate.domain.Mate;
 import com.ody.mate.domain.Nickname;
 import com.ody.meeting.domain.Location;
@@ -7,6 +8,7 @@ import com.ody.meeting.domain.Meeting;
 import com.ody.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@SupportRegion(latitudeFieldName = "originLatitude", longitudeFieldName = "originLongitude")
 public record MateSaveRequest(
 
         @Schema(description = "초대코드", example = "inviteCodeinviteCode")

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -135,7 +135,7 @@ public class MeetingController implements MeetingControllerSwagger {
     public ResponseEntity<MateEtaResponses> findAllMateEtas(
             @AuthMember Member member,
             @PathVariable Long meetingId,
-            @RequestBody MateEtaRequest mateEtaRequest
+            @Valid @RequestBody MateEtaRequest mateEtaRequest
     ) {
         MateEtaResponses mateStatuses = etaService.findAllMateEtas(mateEtaRequest, meetingId, member);
         return ResponseEntity.ok(mateStatuses);

--- a/backend/src/main/java/com/ody/meeting/dto/request/MeetingSaveRequestV1.java
+++ b/backend/src/main/java/com/ody/meeting/dto/request/MeetingSaveRequestV1.java
@@ -1,6 +1,7 @@
 package com.ody.meeting.dto.request;
 
 import com.ody.common.annotation.FutureOrPresentDateTime;
+import com.ody.common.annotation.SupportRegion;
 import com.ody.meeting.domain.Location;
 import com.ody.meeting.domain.Meeting;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -8,6 +9,7 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+@SupportRegion(latitudeFieldName = "targetLatitude", longitudeFieldName = "targetLongitude")
 @FutureOrPresentDateTime(dateFieldName = "date", timeFieldName = "time")
 public record MeetingSaveRequestV1(
 

--- a/backend/src/test/java/com/ody/common/validator/SupportRegionValidatorTest.java
+++ b/backend/src/test/java/com/ody/common/validator/SupportRegionValidatorTest.java
@@ -1,0 +1,89 @@
+package com.ody.common.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.ody.common.annotation.SupportRegion;
+import com.ody.mate.dto.request.MateSaveRequest;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SupportRegionValidatorTest {
+
+    private SupportRegionValidator supportRegionValidator;
+
+    @BeforeEach
+    void init() {
+        supportRegionValidator = new SupportRegionValidator();
+        supportRegionValidator.initialize(new SupportRegion() {
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return SupportRegion.class;
+            }
+
+            @Override
+            public String latitudeFieldName() {
+                return "originLatitude";
+            }
+
+            @Override
+            public String longitudeFieldName() {
+                return "originLongitude";
+            }
+
+            @Override
+            public String message() {
+                return "수도권 내 위경도 좌표만 가능합니다.";
+            }
+
+            @Override
+            public Class<?>[] groups() {
+                return new Class[0];
+            }
+
+            @Override
+            public Class<? extends Payload>[] payload() {
+                return new Class[0];
+            }
+        });
+    }
+
+    @DisplayName("수도권 내 위경도 좌표이면 true, 아니면 false를 반환한다.")
+    @ParameterizedTest
+    @MethodSource("supportRegionTestCases")
+    void isValid(String latitude, String longitude, boolean expected) {
+        MateSaveRequest mateSaveRequest = new MateSaveRequest(
+                "testInviteCode",
+                "조조",
+                "서울 강남구",
+                latitude,
+                longitude
+        );
+
+        boolean valid = supportRegionValidator.isValid(
+                mateSaveRequest,
+                mock(ConstraintValidatorContext.class)
+        );
+
+        assertThat(valid).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> supportRegionTestCases() {
+        return Stream.of(
+                Arguments.of("37.505713", "127.050691", true), // 서울
+                Arguments.of("37.694802", "126.318463", true), // 인천
+                Arguments.of("37.291015", "127.724058", true), // 경기
+                Arguments.of("36.747167", "127.418673", false), // 충북
+                Arguments.of("38.099416", "127.979525", false), // 강원
+                Arguments.of("39.031896", "125.769334", false) // 평양
+        );
+    }
+}

--- a/backend/src/test/java/com/ody/common/validator/SupportRegionValidatorTest.java
+++ b/backend/src/test/java/com/ody/common/validator/SupportRegionValidatorTest.java
@@ -4,12 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.ody.common.annotation.SupportRegion;
-import com.ody.mate.dto.request.MateSaveRequest;
+import com.ody.eta.dto.request.MateEtaRequest;
 import jakarta.validation.ConstraintValidatorContext;
 import jakarta.validation.Payload;
 import java.lang.annotation.Annotation;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,61 +17,21 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class SupportRegionValidatorTest {
 
-    private SupportRegionValidator supportRegionValidator;
+    private static SupportRegionValidator supportRegionValidator = new SupportRegionValidator();
 
-    @BeforeEach
-    void init() {
+    @BeforeAll
+    static void setUp() {
         supportRegionValidator = new SupportRegionValidator();
-        supportRegionValidator.initialize(new SupportRegion() {
-
-            @Override
-            public Class<? extends Annotation> annotationType() {
-                return SupportRegion.class;
-            }
-
-            @Override
-            public String latitudeFieldName() {
-                return "originLatitude";
-            }
-
-            @Override
-            public String longitudeFieldName() {
-                return "originLongitude";
-            }
-
-            @Override
-            public String message() {
-                return "수도권 내 위경도 좌표만 가능합니다.";
-            }
-
-            @Override
-            public Class<?>[] groups() {
-                return new Class[0];
-            }
-
-            @Override
-            public Class<? extends Payload>[] payload() {
-                return new Class[0];
-            }
-        });
+        supportRegionValidator.initialize(new SupportRegionStub());
     }
 
     @DisplayName("수도권 내 위경도 좌표이면 true, 아니면 false를 반환한다.")
     @ParameterizedTest
     @MethodSource("supportRegionTestCases")
     void isValid(String latitude, String longitude, boolean expected) {
-        MateSaveRequest mateSaveRequest = new MateSaveRequest(
-                "testInviteCode",
-                "조조",
-                "서울 강남구",
-                latitude,
-                longitude
-        );
+        MateEtaRequest mateEtaRequest = new MateEtaRequest(false, latitude, longitude);
 
-        boolean valid = supportRegionValidator.isValid(
-                mateSaveRequest,
-                mock(ConstraintValidatorContext.class)
-        );
+        boolean valid = supportRegionValidator.isValid(mateEtaRequest, mock(ConstraintValidatorContext.class));
 
         assertThat(valid).isEqualTo(expected);
     }
@@ -85,5 +45,38 @@ class SupportRegionValidatorTest {
                 Arguments.of("38.099416", "127.979525", false), // 강원
                 Arguments.of("39.031896", "125.769334", false) // 평양
         );
+    }
+
+    private static class SupportRegionStub implements SupportRegion {
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return SupportRegion.class;
+        }
+
+        @Override
+        public String latitudeFieldName() {
+            return "currentLatitude";
+        }
+
+        @Override
+        public String longitudeFieldName() {
+            return "currentLongitude";
+        }
+
+        @Override
+        public String message() {
+            return "수도권 내 위경도 좌표만 가능합니다.";
+        }
+
+        @Override
+        public Class<?>[] groups() {
+            return new Class[0];
+        }
+
+        @Override
+        public Class<? extends Payload>[] payload() {
+            return new Class[0];
+        }
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #345 

<br>

# 📝 작업 내용
- 수도권 외 지역 예외처리 커스텀 어노테이션 생성
- 약속 개설, 약속 참여, ETA 조회 request Dto에 검증 로직 적용
- 수도권 좌표 검증 로직: 아래 정사각형 좌표에 내 해당하는지 확인
![image](https://github.com/user-attachments/assets/ff86cc8a-44c1-4454-af8e-0c40990101c7)

<br>

# 🗣️ 리뷰 요구사항

### Q. 수도권 좌표 검증 로직을 `Location` 도메인에도 추가해야 할까요?
Dto를 통해서 한번 검증이 이뤄지지만, 도메인에서도 중복으로 처리하는 게 좋을지 의견 궁금해요🤔
