### PR TITLE
docs: 약속 참여자 도착 현황 조회 API 문서화

### DIFF
--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -1,12 +1,15 @@
 package com.ody.meeting.controller;
 
 import com.ody.common.annotation.AuthMember;
+import com.ody.eta.domain.EtaStatus;
 import com.ody.eta.dto.request.MateEtaRequest;
 import com.ody.eta.dto.response.MateEtaResponses;
 import com.ody.eta.service.EtaService;
 import com.ody.mate.dto.response.MateResponse;
 import com.ody.meeting.dto.request.MeetingSaveRequest;
 import com.ody.meeting.dto.request.MeetingSaveRequestV1;
+import com.ody.meeting.dto.response.MateEtaResponseV2;
+import com.ody.meeting.dto.response.MateEtaResponsesV2;
 import com.ody.meeting.dto.response.MeetingFindByMemberResponses;
 import com.ody.meeting.dto.response.MeetingSaveResponse;
 import com.ody.meeting.dto.response.MeetingSaveResponseV1;
@@ -139,5 +142,23 @@ public class MeetingController implements MeetingControllerSwagger {
     ) {
         MateEtaResponses mateStatuses = etaService.findAllMateEtas(mateEtaRequest, meetingId, member);
         return ResponseEntity.ok(mateStatuses);
+    }
+
+    @Override
+    @PatchMapping("/v2/meetings/{meetingId}/mates/etas")
+    public ResponseEntity<MateEtaResponsesV2> findAllMateEtasV2(
+            @AuthMember Member member,
+            @PathVariable Long meetingId,
+            @Valid @RequestBody MateEtaRequest mateEtaRequest
+    ) {
+        MateEtaResponsesV2 mateEtaResponses = new MateEtaResponsesV2(
+                4,
+                new MateEtaResponseV2(3, "콜리", EtaStatus.LATE_WARNING, 83),
+                new MateEtaResponseV2(2, "올리브", EtaStatus.ARRIVAL_SOON, 10),
+                new MateEtaResponseV2(1, "해음", EtaStatus.ARRIVED, 0),
+                new MateEtaResponseV2(4, "콜리", EtaStatus.MISSING, -1)
+        );
+
+        return ResponseEntity.ok(mateEtaResponses);
     }
 }

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingControllerSwagger.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingControllerSwagger.java
@@ -2,6 +2,7 @@ package com.ody.meeting.controller;
 
 import com.ody.eta.dto.request.MateEtaRequest;
 import com.ody.eta.dto.response.MateEtaResponses;
+import com.ody.meeting.dto.response.MateEtaResponsesV2;
 import com.ody.meeting.dto.request.MeetingSaveRequest;
 import com.ody.meeting.dto.request.MeetingSaveRequestV1;
 import com.ody.meeting.dto.response.MeetingFindByMemberResponses;
@@ -160,13 +161,39 @@ public interface MeetingControllerSwagger {
                             description = "클라이언트 입력 오류 또는 약속 시간 30분 전보다 이른 시간에 조회 시도 시",
                             content = @Content(schema = @Schema(implementation = ProblemDetail.class))
                     )
-            }
+            },
+            deprecated = true
     )
     @ErrorCode400
     @ErrorCode401
     @ErrorCode404(description = "존재하지 않는 약속이거나 해당 약속 참여자가 아닌 경우")
     @ErrorCode500
     ResponseEntity<MateEtaResponses> findAllMateEtas(
+            @Parameter(hidden = true) Member member,
+            Long meetingId,
+            MateEtaRequest mateEtaRequest
+    );
+
+    @Operation(
+            summary = "약속 참여자 도착 현황 조회",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = MateEtaRequest.class))),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "약속 참여자 도착 현황 조회 성공",
+                            content = @Content(schema = @Schema(implementation = MateEtaResponsesV2.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "클라이언트 입력 오류 또는 약속 시간 30분 전보다 이른 시간에 조회 시도 시",
+                            content = @Content(schema = @Schema(implementation = ProblemDetail.class))
+                    )
+            }
+    )
+    @ErrorCode401
+    @ErrorCode404(description = "존재하지 않는 약속이거나 해당 약속 참여자가 아닌 경우")
+    @ErrorCode500
+    ResponseEntity<MateEtaResponsesV2> findAllMateEtasV2(
             @Parameter(hidden = true) Member member,
             Long meetingId,
             MateEtaRequest mateEtaRequest

--- a/backend/src/main/java/com/ody/meeting/dto/response/MateEtaResponseV2.java
+++ b/backend/src/main/java/com/ody/meeting/dto/response/MateEtaResponseV2.java
@@ -1,0 +1,21 @@
+package com.ody.meeting.dto.response;
+
+import com.ody.eta.domain.EtaStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MateEtaResponseV2(
+
+        @Schema(description = "참여자 아이디", example = "3")
+        long mateId,
+
+        @Schema(description = "참여자 닉네임", example = "콜리")
+        String nickname,
+
+        @Schema(description = "참여자 ETA에 따른 상태", example = "LATE_WARNING")
+        EtaStatus status,
+
+        @Schema(description = "도착지까지 남은 소요시간(분)", example = "32")
+        long durationMinutes
+) {
+
+}

--- a/backend/src/main/java/com/ody/meeting/dto/response/MateEtaResponsesV2.java
+++ b/backend/src/main/java/com/ody/meeting/dto/response/MateEtaResponsesV2.java
@@ -1,0 +1,20 @@
+package com.ody.meeting.dto.response;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Arrays;
+import java.util.List;
+
+public record MateEtaResponsesV2(
+
+        @Schema(description = "요청자의 참여자 아이디", example = "4")
+        long requesterMateId,
+
+        @ArraySchema(schema = @Schema(implementation = MateEtaResponseV2.class))
+        List<MateEtaResponseV2> mateEtas
+) {
+
+    public MateEtaResponsesV2(long requesterMateId, MateEtaResponseV2... mateEtaResponseV2) {
+        this(requesterMateId, Arrays.asList(mateEtaResponseV2));
+    }
+}


### PR DESCRIPTION
# 🚩 연관 이슈 
close #400


<br>

# 📝 작업 내용
- `ownerNickname` 대신 `requesterMateId` 제공
- `MateEtaResponse` 내 `mateId` 제공
- `ownerNickname`을 제공하지 않게 되면서 API가 깨져서 버전을 `v2`로 올렸습니다

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
