### PR TITLE
chore: MySQL DB를 실행할 EC2 생성 및 프로덕션 EC2 서버와 연결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,9 +50,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.rest-assured:rest-assured:5.3.1'
 
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	runtimeOnly 'com.mysql:mysql-connector-j:8.4.0'
 
-	runtimeOnly 'com.h2database:h2'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 
 	annotationProcessor 'org.projectlombok:lombok'
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/ody/eta/domain/Eta.java
+++ b/backend/src/main/java/com/ody/eta/domain/Eta.java
@@ -33,15 +33,20 @@ public class Eta {
     @JoinColumn(name = "mate_id")
     private Mate mate;
 
+    @NotNull
     private long remainingMinutes;
 
+    @NotNull
     private boolean isArrived;
 
+    @NotNull
     private boolean isMissing;
 
     @Column(updatable = false)
+    @NotNull
     private LocalDateTime createdAt;
 
+    @NotNull
     private LocalDateTime updatedAt;
 
     public Eta(Mate mate, Long remainingMinutes) {

--- a/backend/src/main/java/com/ody/meeting/service/MeetingService.java
+++ b/backend/src/main/java/com/ody/meeting/service/MeetingService.java
@@ -82,6 +82,7 @@ public class MeetingService {
         return MeetingWithMatesResponse.of(meeting, mates);
     }
 
+    @Transactional
     public MateSaveResponse saveMateAndSendNotifications(MateSaveRequest mateSaveRequest, Member member) {
         Meeting meeting = findByInviteCode(mateSaveRequest.inviteCode());
         return mateService.saveAndSendNotifications(mateSaveRequest, member, meeting);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,7 +4,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    defer-datasource-initialization: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,25 +1,16 @@
 spring:
   config:
     import: classpath:private/private.yml
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-      settings:
-        web-allow-others: true
-  datasource:
-    url: jdbc:h2:mem:database
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
   jpa:
-    show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
+    defer-datasource-initialization: true
     properties:
       hibernate:
-        format_sql: true
-    defer-datasource-initialization: true
+        dialect: org.hibernate.dialect.MySQLDialect
+  sql:
+    init:
+      mode: always
   profiles:
     active: dev
 

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -35,13 +35,13 @@ create table if not exists mate (
 create table if not exists eta (
     id bigint not null auto_increment,
     mate_id bigint not null,
-    is_arrived boolean not null,
-    is_missing boolean not null,
     remaining_minutes bigint not null,
-    created_at timestamp(6) not null,
-    updated_at timestamp(6) not null,
+    is_arrived tinyint(1) not null default false,
+    is_missing tinyint(1) not null default false,
+    created_at timestamp not null default current_timestamp(),
+    updated_at timestamp not null default current_timestamp(),
     primary key (id),
-    constraint fk_mate_id foreign key (mate_id) references mate (id)
+    constraint fk_eta_mate_id foreign key (mate_id) references mate (id)
 );
 
 create table if not exists notification (
@@ -49,8 +49,8 @@ create table if not exists notification (
     mate_id bigint not null,
     `type` varchar(225) check (`type` in ('departure_reminder','entry')) not null,
     status varchar(225) check (status in ('done','pending')) not null,
-    send_at timestamp(6) not null,
-    created_at timestamp(6) not null default current_timestamp,
+    send_at timestamp not null,
+    created_at timestamp not null default current_timestamp(),
     primary key (id),
-    constraint fk_mate_id foreign key (mate_id) references mate (id)
+    constraint fk_notification_mate_id foreign key (mate_id) references mate (id)
 );

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -1,0 +1,56 @@
+create table if not exists member (
+    id bigint not null auto_increment,
+    device_token varchar(255) not null unique,
+    primary key (id)
+);
+
+create table if not exists meeting (
+    id bigint not null auto_increment,
+    `name` varchar(255) not null,
+    `date` date not null,
+    `time` time not null,
+    address varchar(255) not null,
+    latitude varchar(255) not null,
+    longitude varchar(255) not null,
+    invite_code varchar(255) not null,
+    primary key (id)
+);
+
+create table if not exists mate (
+    id bigint not null auto_increment,
+    meeting_id bigint not null,
+    member_id bigint not null,
+    address varchar(255) not null,
+    latitude varchar(255) not null,
+    longitude varchar(255) not null,
+    nickname varchar(255) not null,
+    estimated_minutes bigint not null,
+    primary key (id),
+    constraint fk_meeting_id foreign key (meeting_id) references meeting (id),
+    constraint fk_member_id foreign key (member_id) references member (id),
+    constraint unique_meeting_and_nickname unique (meeting_id, nickname),
+    constraint unique_meeting_and_member unique (meeting_id, member_id)
+);
+
+create table if not exists eta (
+    id bigint not null auto_increment,
+    mate_id bigint not null,
+    is_arrived boolean not null,
+    is_missing boolean not null,
+    remaining_minutes bigint not null,
+    created_at timestamp(6) not null,
+    updated_at timestamp(6) not null,
+    primary key (id),
+    constraint fk_mate_id foreign key (mate_id) references mate (id)
+);
+
+create table if not exists notification (
+    id bigint not null auto_increment,
+    mate_id bigint not null,
+    `type` varchar(225) check (`type` in ('departure_reminder','entry')) not null,
+    status varchar(225) check (status in ('done','pending')) not null,
+    send_at timestamp(6) not null,
+    created_at timestamp(6) not null default current_timestamp,
+    primary key (id),
+    constraint fk_mate_id foreign key (mate_id) references mate (id)
+);

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -13,6 +13,7 @@ create table if not exists meeting (
     latitude varchar(255) not null,
     longitude varchar(255) not null,
     invite_code varchar(255) not null,
+    created_at timestamp not null default current_timestamp(),
     primary key (id)
 );
 
@@ -36,10 +37,10 @@ create table if not exists eta (
     id bigint not null auto_increment,
     mate_id bigint not null,
     remaining_minutes bigint not null,
-    is_arrived tinyint(1) not null default false,
-    is_missing tinyint(1) not null default false,
-    created_at timestamp not null default current_timestamp(),
-    updated_at timestamp not null default current_timestamp(),
+    is_arrived boolean not null,
+    is_missing boolean not null,
+    created_at timestamp not null,
+    updated_at timestamp not null,
     primary key (id),
     constraint fk_eta_mate_id foreign key (mate_id) references mate (id)
 );

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -17,7 +17,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-    defer-datasource-initialization: true
   sql:
     init:
       schema-locations:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -18,6 +18,9 @@ spring:
       hibernate:
         format_sql: true
     defer-datasource-initialization: true
+  sql:
+    init:
+      schema-locations:
 
 odsay:
   url: https://api.odsay.com/v1/api/searchPubTransPathT


### PR DESCRIPTION
# 🚩 연관 이슈 
close #373


<br>

# 📝 작업 내용
- MySQL DB를 실행할 EC2 생성 및 프로덕션 EC2 서버와 연결
- ddl 옵션을 validate로 변경
- schema.sql 추가


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
