### PR TITLE
chore: 로그 관련 중복 코드 제거 및 로그 내 Request Body 개행 제거

### DIFF
--- a/backend/src/main/java/com/ody/common/interceptor/LoggingInterceptor.java
+++ b/backend/src/main/java/com/ody/common/interceptor/LoggingInterceptor.java
@@ -1,14 +1,11 @@
 package com.ody.common.interceptor;
 
+import com.ody.common.interceptor.dto.RequestResponseWrappers;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.util.ContentCachingRequestWrapper;
-import org.springframework.web.util.ContentCachingResponseWrapper;
 
 @Slf4j
 @Component
@@ -17,35 +14,14 @@ public class LoggingInterceptor implements HandlerInterceptor {
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
             throws Exception {
-        ContentCachingRequestWrapper requestWrapper = (ContentCachingRequestWrapper) request;
-        ContentCachingResponseWrapper responseWrapper = (ContentCachingResponseWrapper) response;
+        RequestResponseWrappers wrappers = new RequestResponseWrappers(request, response);
 
-        if (responseWrapper.getStatus() >= 500) {
-            log.error("[Request] {} {}, Query: {}, Headers: {}, Body: {} [Response] {}",
-                    requestWrapper.getMethod(),
-                    requestWrapper.getRequestURI(),
-                    requestWrapper.getQueryString(),
-                    requestWrapper.getHeader(HttpHeaders.AUTHORIZATION),
-                    new String(requestWrapper.getContentAsByteArray()),
-                    responseWrapper.getStatus());
-        } else if (responseWrapper.getStatus() >= 400) {
-            log.warn("[Request] {} {}, Query: {}, Headers: {}, Body: {} [Response] {}",
-                    requestWrapper.getMethod(),
-                    requestWrapper.getRequestURI(),
-                    requestWrapper.getQueryString(),
-                    requestWrapper.getHeader(HttpHeaders.AUTHORIZATION),
-                    new String(requestWrapper.getContentAsByteArray()),
-                    responseWrapper.getStatus());
+        if (response.getStatus() >= 500) {
+            log.error(wrappers.requestMessageWithResponseStatus());
+        } else if (response.getStatus() >= 400) {
+            log.warn(wrappers.requestMessageWithResponseStatus());
         } else {
-            log.info("[Request] {} {}, Query: {}, Headers: {}, Body: {} [Response] {}, Body: {}",
-                    requestWrapper.getMethod(),
-                    requestWrapper.getRequestURI(),
-                    requestWrapper.getQueryString(),
-                    requestWrapper.getHeader(HttpHeaders.AUTHORIZATION),
-                    new String(requestWrapper.getContentAsByteArray()),
-                    responseWrapper.getStatus(),
-                    new String(responseWrapper.getContentAsByteArray())
-            );
+            log.info(wrappers.requestAndResponseMessage());
         }
     }
 }

--- a/backend/src/main/java/com/ody/common/interceptor/ServletWappingFilter.java
+++ b/backend/src/main/java/com/ody/common/interceptor/ServletWappingFilter.java
@@ -13,7 +13,7 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 @Component
-public class CustomFilter implements Filter {
+public class ServletWappingFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)

--- a/backend/src/main/java/com/ody/common/interceptor/dto/RequestResponseWrappers.java
+++ b/backend/src/main/java/com/ody/common/interceptor/dto/RequestResponseWrappers.java
@@ -6,14 +6,14 @@ import org.apache.http.HttpHeaders;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
-public record RequestResponseWrappers(
+public class RequestResponseWrappers {
 
-        ContentCachingRequestWrapper requestWrapper,
-        ContentCachingResponseWrapper responseWrapper
-) {
+    private final ContentCachingRequestWrapper requestWrapper;
+    private final ContentCachingResponseWrapper responseWrapper;
 
     public RequestResponseWrappers(HttpServletRequest request, HttpServletResponse response) {
-        this((ContentCachingRequestWrapper) request, (ContentCachingResponseWrapper) response);
+        requestWrapper = (ContentCachingRequestWrapper) request;
+        responseWrapper = (ContentCachingResponseWrapper) response;
     }
 
     public String requestAndResponseMessage() {

--- a/backend/src/main/java/com/ody/common/interceptor/dto/RequestResponseWrappers.java
+++ b/backend/src/main/java/com/ody/common/interceptor/dto/RequestResponseWrappers.java
@@ -1,0 +1,39 @@
+package com.ody.common.interceptor.dto;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.http.HttpHeaders;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+public record RequestResponseWrappers(
+
+        ContentCachingRequestWrapper requestWrapper,
+        ContentCachingResponseWrapper responseWrapper
+) {
+
+    public RequestResponseWrappers(HttpServletRequest request, HttpServletResponse response) {
+        this((ContentCachingRequestWrapper) request, (ContentCachingResponseWrapper) response);
+    }
+
+    public String requestAndResponseMessage() {
+        return requestMessageWithResponseStatus()
+                +
+                String.format(", Body: %s", new String(responseWrapper.getContentAsByteArray()));
+    }
+
+    public String requestMessageWithResponseStatus() {
+        return String.format("[Request] %s %s, Query: %s, Headers: %s, Body: %s [Response] %s",
+                requestWrapper.getMethod(),
+                requestWrapper.getRequestURI(),
+                requestWrapper.getQueryString(),
+                requestWrapper.getHeader(HttpHeaders.AUTHORIZATION),
+                removeNewlines(new String(requestWrapper.getContentAsByteArray())),
+                responseWrapper.getStatus()
+        );
+    }
+
+    private String removeNewlines(String body) {
+        return body.replaceAll("\\n|\\s{2}", "");
+    }
+}

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -2,6 +2,7 @@
 
 <configuration>
     <springProperty scope="context" name="LOG_FILE_PATH" source="log.file.path"/>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
     <appender name="ODY_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
@@ -12,7 +13,7 @@
         </filter>
         <encoder>
             <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} [%level] [%thread] [%logger{36}] - %msg%n
+                %d{yyyy-MM-dd HH:mm:ss.SSS} %clr([%level]) [%thread] %cyan([%logger{36}]) - %msg%n
             </pattern>
         </encoder>
     </appender>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <configuration>
-    <springProperty scope="context" name="LOG_FILE_PATH" source="log.file.path"/>
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+    <springProperty scope="context" name="LOG_FILE_PATH" source="log.file.path"/>
+    <property name="LOG_CONSOLE_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS, UTC+09:00} %clr([%level]) [%thread] %cyan([%logger{36}]) - %msg%n"/>
+    <property name="LOG_FILE_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS, UTC+09:00} [%level] [%thread] [%logger{36}] - %msg%n"/>
 
     <appender name="ODY_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
@@ -12,9 +16,7 @@
             <onMismatch>ACCEPT</onMismatch>
         </filter>
         <encoder>
-            <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} %clr([%level]) [%thread] %cyan([%logger{36}]) - %msg%n
-            </pattern>
+            <pattern>${LOG_CONSOLE_PATTERN}</pattern>
         </encoder>
     </appender>
 
@@ -34,9 +36,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} [%level] [%thread] [%logger{36}] - %msg%n
-            </pattern>
+            <pattern>${LOG_FILE_PATTERN}</pattern>
         </encoder>
     </appender>
 
@@ -56,9 +56,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} [%level] [%thread] [%logger{36}] - %msg%n
-            </pattern>
+            <pattern>${LOG_FILE_PATTERN}</pattern>
         </encoder>
     </appender>
 
@@ -78,9 +76,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} [%level] [%thread] [%logger{36}] - %msg%n
-            </pattern>
+            <pattern>${LOG_FILE_PATTERN}</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
# 🚩 연관 이슈 
close #355 

<br>

# 📝 작업 내용
### 1. 콘솔 로그 level별 다른 색상 출력되는 옵션 추가
- File에 저장되는 로그에는 색상 옵션을 사용하지 않았습니다. -> File 내 불필요한 특수문자가 많이 들어가서 가독성 해침

### 2. 로그 관련 중복 코드 제거
- `LoggingInterceptor` 로그 출력 중복 코드 -> `RequestResponseWrappers` DTO로 분리
- `logback-spring.xml` 중복 코드 제거를 시도 -> 실패
  시도한 방법들(공통 appender를 정의해서 extends 받는 방법, 여러 태그를 property로 한 번에 정의하는 방법, root 내에 공통 속성을 정의하는 방법.. 등)
-> **Q. 혹시 방법을 찾으셨다면 공유해주시면 감사드리겠습니다~!**

### 3. 로그 내 Request Body 개행 제거
**[문제 상황]** request body 로그 출력시 의도치 않은 개행이 있었습니다.
![image](https://github.com/user-attachments/assets/127eacb7-160f-4b78-b6fb-ec46224cc234)

**[원인]** Swagger에서 요청 body에 개행이 들어가기 때문이었습니다.
<img src="https://github.com/user-attachments/assets/bed85c26-2885-4ed9-beaf-9d36f4db76e0" width=50%>

**[해결]** 개행, 공백2개 제거 `body.replaceAll("\\n|\\s{2}", "");`
