### PR TITLE
chore: 안드로이드 CD 구축

### DIFF
--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -56,17 +56,17 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew bundleRelease
 
-      - name: sign app aab
+      - name: Sign app aab
         id: sign_app
         uses: r0adkll/sign-android-release@v1
         with:
           releaseDirectory: /home/runner/work/2024-ody/2024-ody/android/app/build/outputs/bundle/release
-          signingKeyBase64: ${{ secrets.SIGNING_KEY}}
-          alias: ${{ secrets.ALIAS}}
-          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD}}
-          keyPassword: ${{ secrets.KEY_PASSWORD}}
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
 
-      - name: deploy to play console
+      - name: Deploy to play console
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}

--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -1,0 +1,76 @@
+name: android cd
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - android/**
+    types:
+      - closed
+
+defaults:
+  run:
+    working-directory: android
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Add google-services.json
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ./app/google-services.json
+
+      - name: Add local.properties
+        run: |
+          echo base_url='${{ secrets.BASE_URL }}' > ./local.properties
+          echo kakao_api_key='{{ secrets.KAKAO_API_KEY }}' > ./local.properties
+          echo kakao_native_key='{{ secrets.KAKAO_NATIVE_KEY }}' > ./local.properties
+
+      - name: Change gradlew permissions
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew bundleRelease
+
+      - name: sign app aab
+        id: sign_app
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: /home/runner/work/2024-ody/2024-ody/android/app/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY}}
+          alias: ${{ secrets.ALIAS}}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD}}
+          keyPassword: ${{ secrets.KEY_PASSWORD}}
+
+      - name: deploy to play console
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+          packageName: com.woowacourse.ody
+          releaseFiles: /home/runner/work/2024-ody/2024-ody/android/app/build/outputs/bundle/release/app-release.aab
+          track: internal
+          status: draft


### PR DESCRIPTION
# 📝 작업 내용
- [x] main 브랜치에 앱을 머지할 때 수행
- [x] aab 파일 빌드
- [x] keystore base64로 인코딩
- [x] keystore, alias, keystore_password, key_password로 앱 사이닝
- [x] play console에 앱을 업로드 하기 전 사전 준비
    - [x] gcp에 서비스 계정 생성
    - [x] 서비스 계정의 key json 생성 (SERVICE_ACCOUNT_JSON)
    - [x] play console 사용자 및 권한에 생성한 서비스 계정 등록
- [x] 서비스 계정의 key json을 이용해 play console 비공개 테스트 트랙에 앱을 게시