### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/.github/workflows/android-ci-dev.yml
+++ b/.github/workflows/android-ci-dev.yml
@@ -50,6 +50,8 @@ jobs:
           echo base_url='${{ secrets.BASE_URL }}' > ./local.properties
           echo kakao_api_key='{{ secrets.KAKAO_API_KEY }}' > ./local.properties
           echo kakao_native_key='{{ secrets.KAKAO_NATIVE_KEY }}' > ./local.properties
+          echo term_uri='{{ secrets.TERM_URI }}' > ./local.properties
+          echo privacy_policy_uri='{{ secrets.PRIVACY_POLICY_URI }}' > ./local.properties
 
       - name: Check ktLint
         run: ./gradlew ktlintCheck

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -29,6 +29,8 @@ android {
         buildConfigField("String", "BASE_URL", properties["BASE_URL"].toString())
         buildConfigField("String", "KAKAO_API_KEY", properties["KAKAO_API_KEY"].toString())
         buildConfigField("String", "KAKAO_NATIVE_KEY", properties["KAKAO_NATIVE_KEY"].toString())
+        buildConfigField("String", "PRIVACY_POLICY_URI", properties["PRIVACY_POLICY_URI"].toString())
+        buildConfigField("String", "TERM_URI", properties["TERM_URI"].toString())
         manifestPlaceholders["KAKAO_NATIVE_KEY"] = properties["KAKAO_NATIVE_KEY"].toString().trim('"')
     }
     buildTypes {

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -30,5 +30,9 @@
 -dontwarn org.openjsse.**
 
 # retrofit
--keep class com.mulberry.ody.data.retrofit.* { <fields>; }
+-keep class com.mulberry.ody.data.retrofit.* { *; }
 -keep class com.mulberry.ody.domain.apiresult.ApiResult
+
+# moshi
+-keep class com.squareup.moshi.** { *; }
+-keep class com.mulberry.ody.data.remote.thirdparty.location.entity.response.** { *; }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,21 +34,24 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
-            android:name=".presentation.setting.SettingActivity"
-            android:exported="false"
-            android:screenOrientation="portrait" />
-        <activity
-            android:name=".presentation.login.LoginActivity"
+            android:name=".presentation.splash.SplashActivity"
             android:exported="true"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
-
                 <action android:name="android.intent.action.VIEW" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".presentation.setting.SettingActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+        <activity
+            android:name=".presentation.login.LoginActivity"
+            android:exported="false"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/android/app/src/main/java/com/mulberry/ody/OdyApplication.kt
+++ b/android/app/src/main/java/com/mulberry/ody/OdyApplication.kt
@@ -14,6 +14,7 @@ import com.mulberry.ody.data.remote.core.repository.DefaultMeetingRepository
 import com.mulberry.ody.data.remote.core.repository.DefaultNotificationLogRepository
 import com.mulberry.ody.data.remote.core.service.JoinService
 import com.mulberry.ody.data.remote.core.service.LoginService
+import com.mulberry.ody.data.remote.core.service.LogoutService
 import com.mulberry.ody.data.remote.core.service.MeetingService
 import com.mulberry.ody.data.remote.core.service.NotificationService
 import com.mulberry.ody.data.remote.core.service.RefreshTokenService
@@ -63,6 +64,7 @@ class OdyApplication : Application() {
     private val joinService: JoinService = retrofit.create(JoinService::class.java)
     private val meetingService: MeetingService = retrofit.create(MeetingService::class.java)
     private val loginService: LoginService = loginRetrofit.create(LoginService::class.java)
+    private val logoutService: LogoutService = retrofit.create(LogoutService::class.java)
     private val notificationService: NotificationService =
         retrofit.create(NotificationService::class.java)
     private val kakaoLocationService: KakaoLocationService =
@@ -92,6 +94,7 @@ class OdyApplication : Application() {
     val kakaoLoginRepository: KakaoLoginRepository by lazy {
         KakaoLoginRepository(
             loginService,
+            logoutService,
             odyDatastore,
             KakaoOAuthLoginService(),
             fcmTokenRepository,

--- a/android/app/src/main/java/com/mulberry/ody/data/local/db/OdyDatastore.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/db/OdyDatastore.kt
@@ -50,6 +50,13 @@ class OdyDatastore(private val context: Context) {
         }
     }
 
+    suspend fun removeAuthToken() {
+        context.dataStore.edit {
+            it.remove(ACCESS_TOKEN)
+            it.remove(REFRESH_TOKEN)
+        }
+    }
+
     companion object {
         private const val ODY_KEY = "ody_key"
         private val INVITE_CODE = stringPreferencesKey("inviteCode")

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/core/service/LogoutService.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/core/service/LogoutService.kt
@@ -1,0 +1,9 @@
+package com.mulberry.ody.data.remote.core.service
+
+import com.mulberry.ody.domain.apiresult.ApiResult
+import retrofit2.http.POST
+
+interface LogoutService {
+    @POST("/v1/auth/logout")
+    suspend fun postLogout(): ApiResult<Unit>
+}

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/login/kakao/KakaoLoginRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/login/kakao/KakaoLoginRepository.kt
@@ -48,7 +48,7 @@ class KakaoLoginRepository(
     suspend fun logout(): ApiResult<Unit> {
         val kakaoLogoutRequest = kakaoOAuthLoginService.logout()
         val logoutRequest = logoutService.postLogout()
-        odyDatastore.removeAuthToken() // 로그아웃이 실패하더라도 토큰을 지웁니다.
+        odyDatastore.removeAuthToken()
 
         if (kakaoLogoutRequest.isFailure) {
             val exception =

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/login/kakao/KakaoLoginRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/login/kakao/KakaoLoginRepository.kt
@@ -5,6 +5,7 @@ import com.mulberry.ody.data.local.db.OdyDatastore
 import com.mulberry.ody.data.remote.core.entity.login.mapper.toAuthToken
 import com.mulberry.ody.data.remote.core.entity.login.request.LoginRequest
 import com.mulberry.ody.data.remote.core.service.LoginService
+import com.mulberry.ody.data.remote.core.service.LogoutService
 import com.mulberry.ody.data.remote.thirdparty.login.entity.UserProfile
 import com.mulberry.ody.domain.apiresult.ApiResult
 import com.mulberry.ody.domain.apiresult.map
@@ -14,6 +15,7 @@ import com.mulberry.ody.domain.repository.ody.FCMTokenRepository
 
 class KakaoLoginRepository(
     private val loginService: LoginService,
+    private val logoutService: LogoutService,
     private val odyDatastore: OdyDatastore,
     private val kakaoOAuthLoginService: KakaoOAuthLoginService,
     private val fcmTokenRepository: FCMTokenRepository,
@@ -41,6 +43,22 @@ class KakaoLoginRepository(
             odyDatastore.setAuthToken(token)
             token
         }
+    }
+
+    suspend fun logout(): ApiResult<Unit> {
+        val kakaoLogoutRequest = kakaoOAuthLoginService.logout()
+        val logoutRequest = logoutService.postLogout()
+        odyDatastore.removeAuthToken() // 로그아웃이 실패하더라도 토큰을 지웁니다.
+
+        if (kakaoLogoutRequest.isFailure) {
+            val exception =
+                kakaoLogoutRequest.exceptionOrNull() ?: return ApiResult.Unexpected(
+                    Exception("kakaoLogoutRequest가 null입니다"),
+                )
+            return ApiResult.Unexpected(exception)
+        }
+
+        return logoutRequest
     }
 
     private suspend fun buildLoginRequest(userProfile: UserProfile): Result<LoginRequest> =

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/login/kakao/KakaoOAuthLoginService.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/login/kakao/KakaoOAuthLoginService.kt
@@ -16,6 +16,17 @@ class KakaoOAuthLoginService {
         return loginWithKakao(context).flatMap { requestUserProfile() }
     }
 
+    suspend fun logout(): Result<Unit> =
+        suspendCoroutine { continuation ->
+            UserApiClient.instance.logout { error ->
+                if (error != null) {
+                    continuation.resume(Result.failure(error))
+                } else {
+                    continuation.resume(Result.success(Unit))
+                }
+            }
+        }
+
     fun checkIfLogined(): Boolean = TokenManagerProvider.instance.manager.getToken() != null
 
     private suspend fun loginWithKakao(context: Context): Result<AuthToken> =

--- a/android/app/src/main/java/com/mulberry/ody/domain/apiresult/ApiResult.kt
+++ b/android/app/src/main/java/com/mulberry/ody/domain/apiresult/ApiResult.kt
@@ -10,4 +10,16 @@ sealed interface ApiResult<out T> {
     data class NetworkError(val exception: IOException) : ApiResult<Nothing>
 
     class Unexpected(val t: Throwable) : ApiResult<Nothing>
+
+    val isSuccess: Boolean
+        get() = this is Success
+
+    val isFailure: Boolean
+        get() = this is Failure
+
+    val isNetworkError: Boolean
+        get() = this is NetworkError
+
+    val isUnexpected: Boolean
+        get() = this is Unexpected
 }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginActivity.kt
@@ -1,13 +1,9 @@
 package com.mulberry.ody.presentation.login
 
-import android.animation.ObjectAnimator
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
-import androidx.core.animation.doOnEnd
-import androidx.core.splashscreen.SplashScreen
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.mulberry.ody.R
 import com.mulberry.ody.databinding.ActivityLoginBinding
 import com.mulberry.ody.presentation.common.binding.BindingActivity
@@ -21,26 +17,10 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
         )
     }
 
-    private lateinit var splashScreen: SplashScreen
-
     override fun onCreate(savedInstanceState: Bundle?) {
-        splashScreen = installSplashScreen()
-        startSplash()
         super.onCreate(savedInstanceState)
         initializeObserve()
         viewModel.checkIfLogined()
-    }
-
-    private fun startSplash() {
-        splashScreen.setOnExitAnimationListener { splashScreenView ->
-            ObjectAnimator.ofPropertyValuesHolder(splashScreenView.iconView).run {
-                duration = SPLASH_DELAY_DURATION
-                doOnEnd {
-                    splashScreenView.remove()
-                }
-                start()
-            }
-        }
     }
 
     override fun initializeBinding() {
@@ -51,7 +31,6 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
         viewModel.navigateAction.observe(this) {
             val intent = MeetingsActivity.getIntent(this@LoginActivity)
             startActivity(intent)
-            finish()
         }
         viewModel.networkErrorEvent.observe(this) {
             showRetrySnackBar { viewModel.retryLastAction() }
@@ -62,8 +41,6 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
     }
 
     companion object {
-        private const val SPLASH_DELAY_DURATION = 1500L
-
         fun getIntent(context: Context): Intent {
             return Intent(context, LoginActivity::class.java)
         }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginActivity.kt
@@ -20,6 +20,7 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initializeObserve()
+        viewModel.checkIfNavigated()
         viewModel.checkIfLogined()
     }
 
@@ -28,6 +29,16 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
     }
 
     private fun initializeObserve() {
+        viewModel.navigatedReason.observe(this) {
+            when (it) {
+                LoginNavigatedReason.LOGOUT -> {
+                    showSnackBar(R.string.logout_success)
+                }
+                LoginNavigatedReason.WITHDRAWAL -> {
+                    showSnackBar(R.string.withdrawal_success)
+                }
+            }
+        }
         viewModel.navigateAction.observe(this) {
             val intent = MeetingsActivity.getIntent(this@LoginActivity)
             startActivity(intent)

--- a/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginActivity.kt
@@ -32,10 +32,10 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
         viewModel.navigatedReason.observe(this) {
             when (it) {
                 LoginNavigatedReason.LOGOUT -> {
-                    showSnackBar(R.string.logout_success)
+                    showSnackBar(R.string.login_logout_success)
                 }
                 LoginNavigatedReason.WITHDRAWAL -> {
-                    showSnackBar(R.string.withdrawal_success)
+                    showSnackBar(R.string.login_withdrawal_success)
                 }
             }
         }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginNavigatedReason.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginNavigatedReason.kt
@@ -1,0 +1,6 @@
+package com.mulberry.ody.presentation.login
+
+enum class LoginNavigatedReason {
+    LOGOUT,
+    WITHDRAWAL,
+}

--- a/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginViewModel.kt
@@ -1,6 +1,7 @@
 package com.mulberry.ody.presentation.login
 
 import android.content.Context
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.mulberry.ody.data.remote.thirdparty.login.kakao.KakaoLoginRepository
 import com.mulberry.ody.domain.apiresult.onFailure
@@ -15,10 +16,20 @@ import kotlinx.coroutines.launch
 class LoginViewModel(
     private val authTokenRepository: AuthTokenRepository,
     private val kakaoLoginRepository: KakaoLoginRepository,
+    private val savedStateHandle: SavedStateHandle,
 ) : BaseViewModel() {
+    private val _navigatedReason: MutableSingleLiveData<LoginNavigatedReason> = MutableSingleLiveData()
+    val navigatedReason: SingleLiveData<LoginNavigatedReason> get() = _navigatedReason
+
     private val _navigateAction: MutableSingleLiveData<LoginNavigateAction> =
         MutableSingleLiveData()
     val navigateAction: SingleLiveData<LoginNavigateAction> get() = _navigateAction
+
+    fun checkIfNavigated() {
+        savedStateHandle.get<LoginNavigatedReason>(NAVIGATED_REASON) ?.let { reason ->
+            _navigatedReason.setValue(reason)
+        }
+    }
 
     fun checkIfLogined() {
         viewModelScope.launch {
@@ -46,5 +57,9 @@ class LoginViewModel(
 
     private fun navigateToMeetings() {
         _navigateAction.setValue(LoginNavigateAction.NavigateToMeetings)
+    }
+
+    companion object {
+        private val NAVIGATED_REASON = "NAVIGATED_REASON"
     }
 }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginViewModelFactory.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginViewModelFactory.kt
@@ -2,6 +2,8 @@ package com.mulberry.ody.presentation.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.mulberry.ody.data.remote.thirdparty.login.kakao.KakaoLoginRepository
 import com.mulberry.ody.domain.repository.ody.AuthTokenRepository
 
@@ -9,9 +11,12 @@ class LoginViewModelFactory(
     private val authTokenRepository: AuthTokenRepository,
     private val loginRepository: KakaoLoginRepository,
 ) : ViewModelProvider.Factory {
-    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(
+        modelClass: Class<T>,
+        extras: CreationExtras,
+    ): T {
         return if (modelClass.isAssignableFrom(LoginViewModel::class.java)) {
-            LoginViewModel(authTokenRepository, loginRepository) as T
+            LoginViewModel(authTokenRepository, loginRepository, extras.createSavedStateHandle()) as T
         } else {
             throw IllegalArgumentException("Unknown ViewModel class")
         }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
@@ -2,9 +2,11 @@ package com.mulberry.ody.presentation.setting
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.widget.LinearLayout
 import com.google.android.material.divider.MaterialDividerItemDecoration
+import com.mulberry.ody.BuildConfig
 import com.mulberry.ody.R
 import com.mulberry.ody.databinding.ActivitySettingBinding
 import com.mulberry.ody.presentation.common.binding.BindingActivity
@@ -36,9 +38,7 @@ class SettingActivity :
                 dividerInsetStart = dpToPx(SETTING_ITEM_HORIZONTAL_MARGIN_DP)
                 dividerInsetEnd = dpToPx(SETTING_ITEM_HORIZONTAL_MARGIN_DP)
             }
-
         binding.rvSetting.addItemDecoration(dividerItemDecoration)
-
         adapter.submitList(SettingUiModel.entries)
     }
 
@@ -47,9 +47,13 @@ class SettingActivity :
     override fun onClickSettingItem(settingUiModel: SettingUiModel) {
         when (settingUiModel) {
             SettingUiModel.PRIVACY_POLICY -> {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(BuildConfig.PRIVACY_POLICY_URI))
+                startActivity(intent)
             }
 
             SettingUiModel.TERM -> {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(BuildConfig.TERM_URI))
+                startActivity(intent)
             }
 
             SettingUiModel.LOGOUT -> {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
@@ -12,6 +12,7 @@ import com.mulberry.ody.R
 import com.mulberry.ody.databinding.ActivitySettingBinding
 import com.mulberry.ody.presentation.common.binding.BindingActivity
 import com.mulberry.ody.presentation.common.listener.BackListener
+import com.mulberry.ody.presentation.login.LoginActivity
 import com.mulberry.ody.presentation.setting.adapter.SettingsAdapter
 import com.mulberry.ody.presentation.setting.listener.SettingListener
 import com.mulberry.ody.presentation.setting.model.SettingUiModel
@@ -64,11 +65,19 @@ class SettingActivity :
 
             SettingUiModel.LOGOUT -> {
                 viewModel.kakaoLogout()
+                navigateToLogin()
             }
 
             SettingUiModel.WITHDRAW -> {
             }
         }
+    }
+
+    private fun navigateToLogin() {
+        val intent = LoginActivity.getIntent(this)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        startActivity(intent)
+        finish()
     }
 
     private fun dpToPx(dp: Int): Int {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
@@ -101,7 +101,7 @@ class SettingActivity :
     }
 
     companion object {
-        private val NAVIGATED_REASON = "NAVIGATED_REASON"
+        private const val NAVIGATED_REASON = "NAVIGATED_REASON"
         private const val SETTING_ITEM_HORIZONTAL_MARGIN_DP = 26
 
         fun getIntent(context: Context): Intent = Intent(context, SettingActivity::class.java)

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
@@ -32,6 +32,20 @@ class SettingActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initializeSettingAdapter()
+        initializeObserve()
+    }
+
+    private fun initializeObserve() {
+        viewModel.loginNavigateEvent.observe(this) {
+            when (it) {
+                LoginNavigatedReason.LOGOUT -> {
+                    navigateToLogin()
+                }
+
+                LoginNavigatedReason.WITHDRAWAL -> {
+                }
+            }
+        }
     }
 
     override fun initializeBinding() {
@@ -66,7 +80,6 @@ class SettingActivity :
 
             SettingUiModel.LOGOUT -> {
                 viewModel.kakaoLogout()
-                navigateToLogin()
             }
 
             SettingUiModel.WITHDRAW -> {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.widget.LinearLayout
+import android.widget.Toast
 import androidx.activity.viewModels
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.mulberry.ody.BuildConfig
@@ -65,6 +66,7 @@ class SettingActivity :
 
             SettingUiModel.LOGOUT -> {
                 viewModel.kakaoLogout()
+                Toast.makeText(this, R.string.logout_success, Toast.LENGTH_SHORT).show()
                 navigateToLogin()
             }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.widget.LinearLayout
+import androidx.activity.viewModels
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.mulberry.ody.BuildConfig
 import com.mulberry.ody.R
@@ -20,6 +21,11 @@ class SettingActivity :
     BackListener,
     SettingListener {
     private val adapter by lazy { SettingsAdapter(this) }
+    private val viewModel by viewModels<SettingViewModel> {
+        SettingViewModelFactory(
+            application.kakaoLoginRepository,
+        )
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,6 +63,7 @@ class SettingActivity :
             }
 
             SettingUiModel.LOGOUT -> {
+                viewModel.kakaoLogout()
             }
 
             SettingUiModel.WITHDRAW -> {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.widget.LinearLayout
-import android.widget.Toast
 import androidx.activity.viewModels
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.mulberry.ody.BuildConfig
@@ -14,6 +13,7 @@ import com.mulberry.ody.databinding.ActivitySettingBinding
 import com.mulberry.ody.presentation.common.binding.BindingActivity
 import com.mulberry.ody.presentation.common.listener.BackListener
 import com.mulberry.ody.presentation.login.LoginActivity
+import com.mulberry.ody.presentation.login.LoginNavigatedReason
 import com.mulberry.ody.presentation.setting.adapter.SettingsAdapter
 import com.mulberry.ody.presentation.setting.listener.SettingListener
 import com.mulberry.ody.presentation.setting.model.SettingUiModel
@@ -66,7 +66,6 @@ class SettingActivity :
 
             SettingUiModel.LOGOUT -> {
                 viewModel.kakaoLogout()
-                Toast.makeText(this, R.string.logout_success, Toast.LENGTH_SHORT).show()
                 navigateToLogin()
             }
 
@@ -78,6 +77,7 @@ class SettingActivity :
     private fun navigateToLogin() {
         val intent = LoginActivity.getIntent(this)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        intent.putExtra(NAVIGATED_REASON, LoginNavigatedReason.LOGOUT)
         startActivity(intent)
         finish()
     }
@@ -88,6 +88,7 @@ class SettingActivity :
     }
 
     companion object {
+        private val NAVIGATED_REASON = "NAVIGATED_REASON"
         private const val SETTING_ITEM_HORIZONTAL_MARGIN_DP = 26
 
         fun getIntent(context: Context): Intent = Intent(context, SettingActivity::class.java)

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingViewModel.kt
@@ -1,0 +1,15 @@
+package com.mulberry.ody.presentation.setting
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mulberry.ody.data.remote.thirdparty.login.kakao.KakaoLoginRepository
+import kotlinx.coroutines.launch
+
+class SettingViewModel(
+    private val kakaoLoginRepository: KakaoLoginRepository,
+) : ViewModel() {
+    fun kakaoLogout() =
+        viewModelScope.launch {
+            kakaoLoginRepository.logout()
+        }
+}

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingViewModel.kt
@@ -3,13 +3,20 @@ package com.mulberry.ody.presentation.setting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mulberry.ody.data.remote.thirdparty.login.kakao.KakaoLoginRepository
+import com.mulberry.ody.presentation.common.MutableSingleLiveData
+import com.mulberry.ody.presentation.common.SingleLiveData
+import com.mulberry.ody.presentation.login.LoginNavigatedReason
 import kotlinx.coroutines.launch
 
 class SettingViewModel(
     private val kakaoLoginRepository: KakaoLoginRepository,
 ) : ViewModel() {
+    private val _loginNavigateEvent: MutableSingleLiveData<LoginNavigatedReason> = MutableSingleLiveData()
+    val loginNavigateEvent: SingleLiveData<LoginNavigatedReason> get() = _loginNavigateEvent
+
     fun kakaoLogout() =
         viewModelScope.launch {
             kakaoLoginRepository.logout()
+            _loginNavigateEvent.setValue(LoginNavigatedReason.LOGOUT)
         }
 }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingViewModelFactory.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.mulberry.ody.presentation.setting
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.mulberry.ody.data.remote.thirdparty.login.kakao.KakaoLoginRepository
+
+class SettingViewModelFactory(
+    private val kakaoLoginRepository: KakaoLoginRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return if (modelClass.isAssignableFrom(SettingViewModel::class.java)) {
+            SettingViewModel(kakaoLoginRepository) as T
+        } else {
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/android/app/src/main/java/com/mulberry/ody/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/splash/SplashActivity.kt
@@ -1,0 +1,42 @@
+package com.mulberry.ody.presentation.splash
+
+import android.animation.ObjectAnimator
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.animation.doOnEnd
+import androidx.core.splashscreen.SplashScreen
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.mulberry.ody.presentation.login.LoginActivity
+
+class SplashActivity : AppCompatActivity() {
+    private lateinit var splashScreen: SplashScreen
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        splashScreen = installSplashScreen()
+        startSplash()
+        navigateToLogin()
+        super.onCreate(savedInstanceState)
+    }
+
+    private fun startSplash() {
+        splashScreen.setOnExitAnimationListener { splashScreenView ->
+            ObjectAnimator.ofPropertyValuesHolder(splashScreenView.iconView).run {
+                duration = SPLASH_DELAY_DURATION
+                doOnEnd {
+                    splashScreenView.remove()
+                }
+                start()
+            }
+        }
+    }
+
+    private fun navigateToLogin() {
+        val intent = LoginActivity.getIntent(this)
+        startActivity(intent)
+        finish()
+    }
+
+    companion object {
+        private const val SPLASH_DELAY_DURATION = 1500L
+    }
+}

--- a/android/app/src/main/java/com/mulberry/ody/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/splash/SplashActivity.kt
@@ -14,8 +14,8 @@ class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         splashScreen = installSplashScreen()
         startSplash()
-        navigateToLogin()
         super.onCreate(savedInstanceState)
+        navigateToLogin()
     }
 
     private fun startSplash() {

--- a/android/app/src/main/res/layout/activity_splash.xml
+++ b/android/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/purple_800"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.splash.SplashActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <!-- activity_setting -->
     <string name="setting_main_title">설정</string>
     <string name="logout_success">로그아웃 되었습니다.</string>
+    <string name="withdrawal_success">회원 탈퇴 되었습니다.</string>
 
     <!-- item_setting -->
     <string name="item_privacy_policy">개인정보 처리 방침</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
 
     <!-- activity_setting -->
     <string name="setting_main_title">설정</string>
+    <string name="logout_success">로그아웃 되었습니다.</string>
 
     <!-- item_setting -->
     <string name="item_privacy_policy">개인정보 처리 방침</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -89,8 +89,8 @@
 
     <!-- activity_setting -->
     <string name="setting_main_title">설정</string>
-    <string name="logout_success">로그아웃 되었습니다.</string>
-    <string name="withdrawal_success">회원 탈퇴 되었습니다.</string>
+    <string name="setting_logout_success">로그아웃 되었습니다.</string>
+    <string name="setting_withdrawal_success">회원 탈퇴 되었습니다.</string>
 
     <!-- item_setting -->
     <string name="item_privacy_policy">개인정보 처리 방침</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -87,10 +87,12 @@
     <string name="invite_code_input_hint">초대 코드</string>
     <string name="invalid_invite_code">초대 코드가 뭔가 이상한데요? 🤔</string>
 
+    <!-- activity_login -->
+    <string name="login_logout_success">로그아웃 되었습니다.</string>
+    <string name="login_withdrawal_success">회원 탈퇴 되었습니다.</string>
+
     <!-- activity_setting -->
     <string name="setting_main_title">설정</string>
-    <string name="setting_logout_success">로그아웃 되었습니다.</string>
-    <string name="setting_withdrawal_success">회원 탈퇴 되었습니다.</string>
 
     <!-- item_setting -->
     <string name="item_privacy_policy">개인정보 처리 방침</string>


### PR DESCRIPTION
# 🚩 연관 이슈 
close #498 


<br>

# 📝 작업 내용
- [x] 로그아웃 처리
    - [x] 카카오 인증 서버에 로그아웃 요청
    - [x] 오디 서버에 로그아웃 요청
    - [x] 클라이언트 저장소에서 acccess token과 refresh token 삭제
- [x] 로그아웃 처리 후 로그인 화면으로 이동
- [x] 스낵바 메시지로 로그아웃 안내

<br>

# 🏞️ 스크린샷 (선택)


https://github.com/user-attachments/assets/d2f36226-77ab-43f7-9de3-c0c63530ba04



<br>

# 🗣️ 리뷰 요구사항 (선택)
로그아웃 요청이 성공하던 실패하던 저장된 access token과 refresh token을 모두 접근할 수 없도록 삭제하는 방식으로 구현했습니다. 
(카카오도 동일하게 로그아웃에 실패하더라도 토큰을 삭제하는 방식으로 구현되어있네요. [카카오 로그아웃](https://developers.kakao.com/docs/latest/ko/kakaologin/android#logout))

지금은 로그아웃 요청이 실패했을 때 토큰을 지워버리니 로그아웃 재요청을 하지 못하고 서버에 만료 기간이 남은 refresh token이 그대로 남아버리는데요, [logout만을 위한 token을 발급하는 방법](https://medium.com/android-news/solving-offline-logout-problem-f3b50da49e7e)이 있는 것 같습니다. access token을 지우지 않고 계속 재시도하는 방법이 있으나, 앞선 링크에 "저장된 토큰을 누군가 탈취할 수도 있다" 소개되어 있네요. 좋은 예시는 아니나 토큰을 남기는게 별로 좋지 않다는건 동의하고 있습니다.

이대로도 동작에는 문제가 없고, refresh token도 만료 기간이 지나면 쓸 수 없게되니 지금은 그냥 둬도 괜찮지 않을까? 하는 생각입니다. 다른 할 일들도 있고.. 이후에 토큰을 저장할 때 암호화해서 저장하는 것도 생각해 볼 일인 것 같아요.(지금 말고)
