### PR TITLE
chore: Dev 서버 Down 오류 해결 

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -4,7 +4,7 @@ spring:
       ddl-auto: validate
   sql:
     init:
-      mode: never
+      mode: always
       schema-locations: classpath:schema.sql
 
 log:

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -2,9 +2,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
   sql:
     init:
       mode: never

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -13,6 +13,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema.sql
 
 log:
   file:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -2,12 +2,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
   sql:
     init:
-      mode: always
+      mode: never
       schema-locations: classpath:schema.sql
 
 log:

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -19,7 +19,9 @@ create table if not exists meeting (
     latitude varchar(255) not null,
     longitude varchar(255) not null,
     invite_code varchar(255) not null,
+    overdue boolean not null,
     created_at timestamp not null default current_timestamp(),
+    updated_at timestamp not null default current_timestamp(),
     primary key (id)
 );
 
@@ -54,9 +56,11 @@ create table if not exists notification (
     id bigint not null auto_increment,
     mate_id bigint not null,
     `type` varchar(225) check (`type` in ('departure_reminder','entry', 'nudge')) not null,
-    status varchar(225) check (status in ('done','pending')) not null,
     send_at timestamp not null,
+    status varchar(225) check (status in ('done','pending')) not null,
+    fcm_topic varchar(225) null,
     created_at timestamp not null default current_timestamp(),
+    updated_at timestamp not null default current_timestamp(),
     primary key (id),
     constraint fk_notification_mate_id foreign key (mate_id) references mate (id)
 );


### PR DESCRIPTION
# 🚩 연관 이슈 
close #500 


<br>

# 📝 작업 내용
> 스키마 수정

변경된 엔티티 구조와 스키마가 달라 Dev 서버의 컨테이너가 종료되었어요 
<img width="889" alt="image" src="https://github.com/user-attachments/assets/84cf8b6c-63a2-4ce8-8f9e-f633ba967c36">
따라서 변경된 엔티티에 맞게 스키마 수정했습니다.

<br>

> 방언 설정 제거

방언 설정을 하고 있었는 데 아래 WARN 로그로 나오고 있었어요
```
MySQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
```
hibernate.dialect 속성을 명시적으로 설정할 필요가 없다고 나와있어
MySQL 드라이버를 사용하면 자동으로 MySQLDialect를 선택하여 해당 설정 제거했습니다.

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
