### PR TITLE
refactor: 초대코대 코드 유일성 높이도록 개선

### DIFF
--- a/backend/src/main/java/com/ody/common/domain/BaseEntity.java
+++ b/backend/src/main/java/com/ody/common/domain/BaseEntity.java
@@ -3,7 +3,6 @@ package com.ody.common.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
@@ -16,11 +15,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseEntity {
 
     @Column(updatable = false)
-    @NotNull
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @NotNull
     @LastModifiedDate
     private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/com/ody/common/domain/BaseEntity.java
+++ b/backend/src/main/java/com/ody/common/domain/BaseEntity.java
@@ -3,6 +3,7 @@ package com.ody.common.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,9 +16,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseEntity {
 
     @Column(updatable = false)
+    @NotNull
     @CreatedDate
     private LocalDateTime createdAt;
 
+    @NotNull
     @LastModifiedDate
     private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -79,7 +79,7 @@ public class MeetingController implements MeetingControllerSwagger {
             @AuthMember Member member,
             @PathVariable String inviteCode
     ) {
-        meetingService.validateInviteCode(inviteCode);
+        meetingService.findByInviteCode(inviteCode);
         return ResponseEntity.ok()
                 .build();
     }

--- a/backend/src/main/java/com/ody/meeting/domain/Meeting.java
+++ b/backend/src/main/java/com/ody/meeting/domain/Meeting.java
@@ -2,6 +2,7 @@ package com.ody.meeting.domain;
 
 import com.ody.common.domain.BaseEntity;
 import com.ody.util.TimeUtil;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -40,6 +41,7 @@ public class Meeting extends BaseEntity {
     private Location target;
 
     @NotNull
+    @Column(columnDefinition = "CHAR(8)", unique = true)
     private String inviteCode;
 
     @NotNull
@@ -47,10 +49,6 @@ public class Meeting extends BaseEntity {
 
     public Meeting(String name, LocalDate date, LocalTime time, Location target, String inviteCode) {
         this(null, name, date, TimeUtil.trimSecondsAndNanos(time), target, inviteCode, false);
-    }
-
-    public void updateInviteCode(String inviteCode) {
-        this.inviteCode = inviteCode;
     }
 
     public boolean isWithinPast24HoursOrLater() {

--- a/backend/src/main/java/com/ody/meeting/repository/MeetingRepository.java
+++ b/backend/src/main/java/com/ody/meeting/repository/MeetingRepository.java
@@ -28,7 +28,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     Optional<Meeting> findByIdAndOverdueFalse(Long id);
 
-    boolean existsByInviteCode(String inviteCode);
-
     Optional<Meeting> findByInviteCode(String inviteCode);
+
+    boolean existsByInviteCode(String inviteCode);
 }

--- a/backend/src/main/java/com/ody/meeting/repository/MeetingRepository.java
+++ b/backend/src/main/java/com/ody/meeting/repository/MeetingRepository.java
@@ -27,4 +27,8 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     List<Meeting> findAllByUpdatedTodayAndOverdue();
 
     Optional<Meeting> findByIdAndOverdueFalse(Long id);
+
+    boolean existsByInviteCode(String inviteCode);
+
+    Optional<Meeting> findByInviteCode(String inviteCode);
 }

--- a/backend/src/main/java/com/ody/meeting/service/MeetingService.java
+++ b/backend/src/main/java/com/ody/meeting/service/MeetingService.java
@@ -62,7 +62,7 @@ public class MeetingService {
 
     public Meeting findByInviteCode(String inviteCode) {
         return meetingRepository.findByInviteCode(inviteCode)
-                .orElseThrow(() -> new OdyNotFoundException("존재하지 않는 초대코드 입니다."));
+                .orElseThrow(() -> new OdyNotFoundException("존재하지 않는 초대코드입니다."));
     }
 
     public Meeting findById(Long meetingId) {

--- a/backend/src/main/java/com/ody/meeting/service/MeetingService.java
+++ b/backend/src/main/java/com/ody/meeting/service/MeetingService.java
@@ -17,8 +17,6 @@ import com.ody.meeting.repository.MeetingRepository;
 import com.ody.member.domain.Member;
 import com.ody.notification.service.NotificationService;
 import com.ody.util.InviteCodeGenerator;
-import com.ody.util.TimeUtil;
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -34,8 +32,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MeetingService {
 
-    private static final String DEFAULT_INVITE_CODE = "초대코드";
-
     private final MateService mateService;
     private final MeetingRepository meetingRepository;
     private final MateRepository mateRepository;
@@ -43,28 +39,35 @@ public class MeetingService {
 
     @Transactional
     public MeetingSaveResponseV1 saveV1(MeetingSaveRequestV1 meetingSaveRequestV1) {
-        Meeting meeting = meetingRepository.save(meetingSaveRequestV1.toMeeting(DEFAULT_INVITE_CODE));
-        String encodedInviteCode = InviteCodeGenerator.encode(meeting.getId());
-        meeting.updateInviteCode(encodedInviteCode);
+        String inviteCode = generateUniqueInviteCode();
+        Meeting meeting = meetingRepository.save(meetingSaveRequestV1.toMeeting(inviteCode));
         return MeetingSaveResponseV1.from(meeting);
+    }
+
+    private String generateUniqueInviteCode() {
+        String inviteCode = InviteCodeGenerator.generate();
+        while (meetingRepository.existsByInviteCode(inviteCode)) {
+            inviteCode = InviteCodeGenerator.generate();
+        }
+        return inviteCode;
     }
 
     public void validateInviteCode(String inviteCode) {
         try {
             findByInviteCode(inviteCode);
         } catch (OdyNotFoundException exception) {
-            throw new OdyNotFoundException("존재하지 않는 초대 코드 입니다.");
+            throw new OdyNotFoundException("유효하지 않은 초대코드입니다.");
         }
     }
 
     public Meeting findByInviteCode(String inviteCode) {
-        Long meetingId = InviteCodeGenerator.decode(inviteCode);
-        return findById(meetingId);
+        return meetingRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new OdyNotFoundException("존재하지 않는 초대코드 입니다."));
     }
 
     public Meeting findById(Long meetingId) {
         return meetingRepository.findByIdAndOverdueFalse(meetingId)
-                .orElseThrow(() -> new OdyNotFoundException("존재하지 않는 모임입니다."));
+                .orElseThrow(() -> new OdyNotFoundException("존재하지 않는 약속입니다."));
     }
 
     public MeetingFindByMemberResponses findAllByMember(Member member) {

--- a/backend/src/main/java/com/ody/meeting/service/MeetingService.java
+++ b/backend/src/main/java/com/ody/meeting/service/MeetingService.java
@@ -52,14 +52,6 @@ public class MeetingService {
         return inviteCode;
     }
 
-    public void validateInviteCode(String inviteCode) {
-        try {
-            findByInviteCode(inviteCode);
-        } catch (OdyNotFoundException exception) {
-            throw new OdyNotFoundException("유효하지 않은 초대코드입니다.");
-        }
-    }
-
     public Meeting findByInviteCode(String inviteCode) {
         return meetingRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new OdyNotFoundException("존재하지 않는 초대코드입니다."));

--- a/backend/src/main/java/com/ody/util/InviteCodeGenerator.java
+++ b/backend/src/main/java/com/ody/util/InviteCodeGenerator.java
@@ -27,7 +27,6 @@ public class InviteCodeGenerator {
             MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
             return messageDigest.digest(input);
         } catch (NoSuchAlgorithmException exception) {
-            log.error("알고리즘 지원 불가 에러 발생 : {}", exception.getMessage());
             throw new OdyServerErrorException(exception.getMessage());
         }
     }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -4,7 +4,7 @@ spring:
       ddl-auto: validate
   sql:
     init:
-      mode: always
+      mode: never
       schema-locations: classpath:schema.sql
 
 log:

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -20,8 +20,8 @@ create table if not exists meeting (
     longitude varchar(255) not null,
     invite_code char(8) not null unique,
     overdue boolean not null,
-    created_at timestamp default current_timestamp(),
-    updated_at timestamp default current_timestamp(),
+    created_at not null timestamp default current_timestamp(),
+    updated_at not null timestamp default current_timestamp(),
     primary key (id)
 );
 
@@ -59,8 +59,8 @@ create table if not exists notification (
     send_at timestamp not null,
     status varchar(225) check (status in ('done','pending')) not null,
     fcm_topic varchar(225) null,
-    created_at timestamp default current_timestamp(),
-    updated_at timestamp default current_timestamp(),
+    created_at not null timestamp default current_timestamp(),
+    updated_at not null timestamp default current_timestamp(),
     primary key (id),
     constraint fk_notification_mate_id foreign key (mate_id) references mate (id)
 );

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -18,7 +18,7 @@ create table if not exists meeting (
     address varchar(255) not null,
     latitude varchar(255) not null,
     longitude varchar(255) not null,
-    invite_code varchar(255) not null,
+    invite_code char(8) not null unique,
     overdue boolean not null,
     created_at timestamp not null default current_timestamp(),
     updated_at timestamp not null default current_timestamp(),

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -20,8 +20,8 @@ create table if not exists meeting (
     longitude varchar(255) not null,
     invite_code char(8) not null unique,
     overdue boolean not null,
-    created_at timestamp not null default current_timestamp(),
-    updated_at timestamp not null default current_timestamp(),
+    created_at timestamp default current_timestamp(),
+    updated_at timestamp default current_timestamp(),
     primary key (id)
 );
 
@@ -59,8 +59,8 @@ create table if not exists notification (
     send_at timestamp not null,
     status varchar(225) check (status in ('done','pending')) not null,
     fcm_topic varchar(225) null,
-    created_at timestamp not null default current_timestamp(),
-    updated_at timestamp not null default current_timestamp(),
+    created_at timestamp default current_timestamp(),
+    updated_at timestamp default current_timestamp(),
     primary key (id),
     constraint fk_notification_mate_id foreign key (mate_id) references mate (id)
 );

--- a/backend/src/test/java/com/ody/common/Fixture.java
+++ b/backend/src/test/java/com/ody/common/Fixture.java
@@ -26,7 +26,7 @@ public class Fixture {
             LocalDate.now(),
             LocalTime.now(),
             TARGET_LOCATION,
-            "초대코드"
+            "초대코드1"
     );
 
     public static Meeting SOJU_MEETING = new Meeting(
@@ -34,7 +34,7 @@ public class Fixture {
             LocalDate.now().plusDays(1),
             LocalTime.parse("18:00"),
             TARGET_LOCATION,
-            "초대코드"
+            "초대코드2"
     );
 
     public static Meeting ODY_MEETING3 = new Meeting(
@@ -42,7 +42,7 @@ public class Fixture {
             LocalDate.now().plusDays(1),
             LocalTime.parse("12:00"),
             TARGET_LOCATION,
-            "초대코드"
+            "초대코드3"
     );
 
     public static Meeting ODY_MEETING4 = new Meeting(
@@ -50,7 +50,7 @@ public class Fixture {
             LocalDate.now().plusDays(2),
             LocalTime.parse("14:00"),
             TARGET_LOCATION,
-            "초대코드"
+            "초대코드4"
     );
 
     public static Meeting ODY_MEETING5 = new Meeting(
@@ -58,7 +58,7 @@ public class Fixture {
             LocalDate.now().plusDays(1),
             LocalTime.parse("14:00"),
             TARGET_LOCATION,
-            "초대코드"
+            "초대코드5"
     );
 
     public static Member MEMBER1 = new Member("pid1", "콜리1", "imageUrl1", new DeviceToken("dt1"));

--- a/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
+++ b/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
@@ -23,6 +23,7 @@ import com.ody.meeting.repository.MeetingRepository;
 import com.ody.member.domain.DeviceToken;
 import com.ody.member.domain.Member;
 import com.ody.member.repository.MemberRepository;
+import com.ody.util.InviteCodeGenerator;
 import com.ody.util.TimeUtil;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -163,7 +164,7 @@ class MateServiceTest extends BaseServiceTest {
                     time.toLocalDate(),
                     time.toLocalTime(),
                     Fixture.TARGET_LOCATION,
-                    "초대코드"
+                    InviteCodeGenerator.generate()
             );
             return meetingRepository.save(meeting);
         }

--- a/backend/src/test/java/com/ody/meeting/repository/MeetingRepositoryTest.java
+++ b/backend/src/test/java/com/ody/meeting/repository/MeetingRepositoryTest.java
@@ -12,6 +12,7 @@ import com.ody.mate.repository.MateRepository;
 import com.ody.meeting.domain.Meeting;
 import com.ody.member.domain.Member;
 import com.ody.member.repository.MemberRepository;
+import com.ody.util.InviteCodeGenerator;
 import com.ody.util.TimeUtil;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -66,7 +67,7 @@ class MeetingRepositoryTest {
                 oneHoursLater.toLocalDate(),
                 oneHoursLater.toLocalTime(),
                 TARGET_LOCATION,
-                "초대코드"
+                InviteCodeGenerator.generate()
         );
         meetingRepository.save(oneHoursLaterMeeting);
 
@@ -76,7 +77,7 @@ class MeetingRepositoryTest {
                 oneDayBefore.toLocalDate(),
                 oneDayBefore.toLocalTime(),
                 TARGET_LOCATION,
-                "초대코드"
+                InviteCodeGenerator.generate()
         );
         meetingRepository.save(oneDayBeforeMeeting);
 
@@ -86,7 +87,7 @@ class MeetingRepositoryTest {
                 twoDayBefore.toLocalDate(),
                 twoDayBefore.toLocalTime(),
                 TARGET_LOCATION,
-                "초대코드"
+                InviteCodeGenerator.generate()
         );
         meetingRepository.save(twoDayBeforeMeeting);
 
@@ -104,7 +105,7 @@ class MeetingRepositoryTest {
                 oneHoursLater.toLocalDate(),
                 oneHoursLater.toLocalTime(),
                 TARGET_LOCATION,
-                "초대코드"
+                InviteCodeGenerator.generate()
         );
         meetingRepository.save(oneHoursLaterMeeting);
 
@@ -114,7 +115,7 @@ class MeetingRepositoryTest {
                 oneDayBefore.toLocalDate(),
                 oneDayBefore.toLocalTime(),
                 TARGET_LOCATION,
-                "초대코드"
+                InviteCodeGenerator.generate()
         );
         meetingRepository.save(oneDayBeforeMeeting);
 
@@ -124,7 +125,7 @@ class MeetingRepositoryTest {
                 twoDayBefore.toLocalDate(),
                 twoDayBefore.toLocalTime(),
                 TARGET_LOCATION,
-                "초대코드"
+                InviteCodeGenerator.generate()
         );
         meetingRepository.save(twoDayBeforeMeeting);
 
@@ -144,7 +145,7 @@ class MeetingRepositoryTest {
                 dateTime.toLocalDate(),
                 dateTime.toLocalTime(),
                 TARGET_LOCATION,
-                "초대코드",
+                InviteCodeGenerator.generate(),
                 true
         );
         Meeting savedOverdueMeeting = meetingRepository.save(overdueMeeting);
@@ -155,7 +156,7 @@ class MeetingRepositoryTest {
                 dateTime.toLocalDate(),
                 dateTime.toLocalTime(),
                 TARGET_LOCATION,
-                "초대코드",
+                InviteCodeGenerator.generate(),
                 false
         );
         Meeting savedNotOverdueMeeting = meetingRepository.save(notOverdueMeeting);
@@ -164,5 +165,29 @@ class MeetingRepositoryTest {
                 () -> assertThat(meetingRepository.findByIdAndOverdueFalse(savedOverdueMeeting.getId())).isEmpty(),
                 () -> assertThat(meetingRepository.findByIdAndOverdueFalse(savedNotOverdueMeeting.getId())).isPresent()
         );
+    }
+
+    @DisplayName("존재하는 초대코드인지 확인한다.")
+    @Test
+    void existsByInviteCode() {
+        Member member1 = memberRepository.save(Fixture.MEMBER1);
+        Meeting odyMeeting = meetingRepository.save(Fixture.ODY_MEETING);
+        mateRepository.save(new Mate(odyMeeting, member1, new Nickname("조조"), Fixture.ORIGIN_LOCATION, 10L));
+
+        boolean exists = meetingRepository.existsByInviteCode(odyMeeting.getInviteCode());
+
+        assertThat(exists).isTrue();
+    }
+
+    @DisplayName("초대코드로 약속을 조회한다.")
+    @Test
+    void findByInviteCode() {
+        Member member1 = memberRepository.save(Fixture.MEMBER1);
+        Meeting odyMeeting = meetingRepository.save(Fixture.ODY_MEETING);
+        mateRepository.save(new Mate(odyMeeting, member1, new Nickname("조조"), Fixture.ORIGIN_LOCATION, 10L));
+
+        Meeting meeting = meetingRepository.findByInviteCode(odyMeeting.getInviteCode()).get();
+
+        assertThat(meeting).usingRecursiveComparison().isEqualTo(odyMeeting);
     }
 }

--- a/backend/src/test/java/com/ody/util/InviteCodeGeneratorTest.java
+++ b/backend/src/test/java/com/ody/util/InviteCodeGeneratorTest.java
@@ -10,14 +10,11 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class InviteCodeGeneratorTest {
 
-    @DisplayName("모임 ID로 생성한 초대코드를 디코딩한다")
+    @DisplayName("8자리의 초대코드를 생성한다.")
     @Test
     void generateInviteCode() {
-        long meetingId = 10L;
-        String encode = InviteCodeGenerator.encode(meetingId);
+        String inviteCode = InviteCodeGenerator.generate();
 
-        Long decode = InviteCodeGenerator.decode(encode);
-
-        assertThat(meetingId).isEqualTo(decode);
+        assertThat(inviteCode).hasSize(8);
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #506 


<br>

# 📝 작업 내용

> 인코딩 방식 제거

기존에 ID로 초대코드를 인코딩하던 방식이 meeting 저장 시 기본 초대코드 저장 -> 반환된 meeting의 ID로 초대코드 인코딩해 update하는
좋지 않은 흐름들을 만든다고 생각했어요
ID를 사용하나 텍스트를 사용해 조회하던 알아본 결과 텍스트가 너무 길거나 Like 문의 %을 문자열 앞에 붙이는 등이 있지만 않다면
큰 성능 차이가 없는 것 같았습니다.
따라서 기존의 인코딩 방식을 제거하고 다음과 같은 방법으로 유일성이 높은 8자리의 초대 코드를 생성하도록 했어요.

```
UUID의 앞 글자를 따 SHA-256으로 해쉬화된 Byte 추출
추출된 Byte의 앞 4글자를 16진수로 변환해 2글자씩 추가 -> 4  * 2 = 8 글자 추출
```

<br>

> 초대코드 타입 및 제약조건 추가

8글자 고정으로 생성되기에 type을 가변인 varchar() -> char(8)로 변경했습니다.
고정형 타입을 사용함으로써 데이터가 항상 일정한 크기를 가져 데이터를 저장하고 검색하는 데에 효율적이라고 하더라구요

유일성이 높아졌고 중복될 수 없기에 unique 제약조건을 추가했습니다
이로인해 논 클러스터링 인덱스가 생성되 조회시에 더 빠르게 조회가 가능할 것 같아요

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
