### PR TITLE
refactor: 출발 알림이 아닌 type들의 초기 상태를 DONE으로 변경

### DIFF
--- a/backend/src/main/java/com/ody/notification/domain/Notification.java
+++ b/backend/src/main/java/com/ody/notification/domain/Notification.java
@@ -3,6 +3,7 @@ package com.ody.notification.domain;
 import com.ody.common.domain.BaseEntity;
 import com.ody.mate.domain.Mate;
 import com.ody.member.domain.DeviceToken;
+import com.ody.util.TimeUtil;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -79,6 +80,10 @@ public class Notification extends BaseEntity {
 
     public boolean isDepartureReminder() {
         return this.type.isDepartureReminder();
+    }
+
+    public boolean isNow() {
+        return this.sendAt.equals(TimeUtil.nowWithTrim());
     }
 
     public void updateStatusToDone() {

--- a/backend/src/main/java/com/ody/notification/domain/Notification.java
+++ b/backend/src/main/java/com/ody/notification/domain/Notification.java
@@ -60,7 +60,7 @@ public class Notification extends BaseEntity {
     }
 
     public static Notification createEntry(Mate mate) {
-        return new Notification(mate, NotificationType.ENTRY, LocalDateTime.now(), NotificationStatus.PENDING, null);
+        return new Notification(mate, NotificationType.ENTRY, LocalDateTime.now(), NotificationStatus.DONE, null);
     }
 
     public static Notification createDepartureReminder(Mate mate, LocalDateTime sendAt, FcmTopic fcmTopic) {
@@ -74,7 +74,11 @@ public class Notification extends BaseEntity {
     }
 
     public static Notification createNudge(Mate mate) {
-        return new Notification(mate, NotificationType.NUDGE, LocalDateTime.now(), NotificationStatus.PENDING, null);
+        return new Notification(mate, NotificationType.NUDGE, LocalDateTime.now(), NotificationStatus.DONE, null);
+    }
+
+    public boolean isDepartureReminder() {
+        return this.type == NotificationType.DEPARTURE_REMINDER;
     }
 
     public void updateStatusToDone() {

--- a/backend/src/main/java/com/ody/notification/domain/Notification.java
+++ b/backend/src/main/java/com/ody/notification/domain/Notification.java
@@ -78,7 +78,7 @@ public class Notification extends BaseEntity {
     }
 
     public boolean isDepartureReminder() {
-        return this.type == NotificationType.DEPARTURE_REMINDER;
+        return this.type.isDepartureReminder();
     }
 
     public void updateStatusToDone() {

--- a/backend/src/main/java/com/ody/notification/domain/NotificationType.java
+++ b/backend/src/main/java/com/ody/notification/domain/NotificationType.java
@@ -6,4 +6,8 @@ public enum NotificationType {
     DEPARTURE_REMINDER,
     NUDGE,
     ;
+
+    public boolean isDepartureReminder() {
+        return this == DEPARTURE_REMINDER;
+    }
 }

--- a/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
+++ b/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
@@ -33,11 +33,17 @@ public class FcmPushSender {
     private void sendMessage(Message message, Notification notification) {
         try {
             FirebaseMessaging.getInstance().send(message);
-            notification.updateStatusToDone();
-            log.info("알림 상태 업데이트 : {}", notification);
+            updateDepartureReminderToDone(notification);
         } catch (FirebaseMessagingException exception) {
             log.error("Fcm 메시지 전송 실패 : {}", exception.getMessage());
             throw new OdyServerErrorException(exception.getMessage());
+        }
+    }
+
+    private void updateDepartureReminderToDone(Notification notification) {
+        if (notification.isDepartureReminder()) {
+            notification.updateStatusToDone();
+            log.info("출발 알림 상태 업데이트 : {}", notification);
         }
     }
 }

--- a/backend/src/test/java/com/ody/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/ody/notification/service/NotificationServiceTest.java
@@ -74,14 +74,10 @@ class NotificationServiceTest extends BaseServiceTest {
         notificationService.saveAndSendNotifications(savedPastMeeting, mate, member.getDeviceToken());
 
         Optional<Notification> departureNotification = notificationRepository.findAll().stream()
-                .filter(notification -> isDepartureReminder(notification) && isNow(notification))
+                .filter(notification -> notification.isDepartureReminder() && isNow(notification))
                 .findAny();
 
         assertThat(departureNotification).isPresent();
-    }
-
-    private boolean isDepartureReminder(Notification notification) {
-        return notification.getType() == NotificationType.DEPARTURE_REMINDER;
     }
 
     private boolean isNow(Notification notification) {

--- a/backend/src/test/java/com/ody/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/ody/notification/service/NotificationServiceTest.java
@@ -74,15 +74,10 @@ class NotificationServiceTest extends BaseServiceTest {
         notificationService.saveAndSendNotifications(savedPastMeeting, mate, member.getDeviceToken());
 
         Optional<Notification> departureNotification = notificationRepository.findAll().stream()
-                .filter(notification -> notification.isDepartureReminder() && isNow(notification))
+                .filter(notification -> notification.isDepartureReminder() && notification.isNow())
                 .findAny();
 
         assertThat(departureNotification).isPresent();
-    }
-
-    private boolean isNow(Notification notification) {
-        return TimeUtil.trimSecondsAndNanos(notification.getSendAt())
-                .isEqual(TimeUtil.nowWithTrim());
     }
 
     @DisplayName("PENDING 상태의 알림들을 TaskScheduler로 스케줄링 한다.")


### PR DESCRIPTION
# 🚩 연관 이슈 
close #508 


<br>

# 📝 작업 내용
- 출발 알림이 아닌 type들의 초기 상태를 DONE으로 변경
- 출발 알림만 DONE 상태로 변경하는 Update 쿼리를 실행하고 상태 변경 로그가 찍히도록 수정

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
