### PR TITLE
design: 기본적으로 보여주던 수도권 안내 멘트 삭제

### DIFF
--- a/android/app/src/main/res/layout/activity_meeting_join.xml
+++ b/android/app/src/main/res/layout/activity_meeting_join.xml
@@ -71,21 +71,9 @@
             android:maxLines="1"
             android:text="@{vm.departureAddress}"
             android:onClick="@{() -> addressSearchListener.onSearch()}"
-            app:layout_constraintBottom_toTopOf="@id/tv_departure_information"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_departure_front" />
-
-        <TextView
-            android:id="@+id/tv_departure_information"
-            style="@style/pretendard_regular_14"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="7dp"
-            android:text="@string/address_question_information"
-            android:textColor="@color/purple_800"
-            app:layout_constraintStart_toStartOf="@id/et_departure"
-            app:layout_constraintTop_toBottomOf="@id/et_departure" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_next"

--- a/android/app/src/main/res/layout/fragment_meeting_destination.xml
+++ b/android/app/src/main/res/layout/fragment_meeting_destination.xml
@@ -52,21 +52,10 @@
             android:text="@{vm.destinationAddress}"
             android:maxLines="1"
             android:onClick="@{() -> addressSearchListener.onSearch()}"
-            app:layout_constraintBottom_toTopOf="@id/tv_destination_information"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_destination_front" />
 
-        <TextView
-            android:id="@+id/tv_destination_information"
-            style="@style/pretendard_regular_14"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="7dp"
-            android:text="@string/address_question_information"
-            android:textColor="@color/purple_800"
-            app:layout_constraintStart_toStartOf="@id/et_destination"
-            app:layout_constraintTop_toBottomOf="@id/et_destination" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
# 🚩 연관 이슈 
close #515 


<br>

# 📝 작업 내용
- [x] 약속 장소 입력 화면에서 수도권 안내 멘트 삭제
- [x] 출발지 입력 화면에서 수도권 안내 멘트 삭제

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
