### PR TITLE
fix: Dev 서버 Swagger 접속 에러 해결 

### DIFF
--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -19,8 +19,8 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@v4
-        with:
-#          ref: develop
+      #        with:
+      #          ref: develop
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -3,8 +3,8 @@ name: backend-cd-dev
 on:
   push:
     branches:
-      - develop
-
+      - feature/544
+    #      - develop
     paths:
       - backend/**
 
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: develop
+#          ref: develop
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -3,8 +3,7 @@ name: backend-cd-dev
 on:
   push:
     branches:
-      - feature/544
-    #      - develop
+      - develop
     paths:
       - backend/**
 
@@ -19,8 +18,8 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@v4
-      #        with:
-      #          ref: develop
+        with:
+          ref: develop
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/backend/src/main/java/com/ody/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/ody/notification/repository/NotificationRepository.java
@@ -20,6 +20,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             """)
     List<Notification> findAllMeetingLogs(Long meetingId);
 
+    @Query("""
+            select noti
+            from Notification noti
+            join fetch Mate mate on noti.mate.id = mate.id
+            join fetch Meeting meet on mate.meeting.id = meet.id
+            join fetch Member member on mate.member.id = member.id
+            where noti.type = :type and noti.status = :status
+            """)
     List<Notification> findAllByTypeAndStatus(NotificationType type, NotificationStatus status);
 
     @Query("""

--- a/backend/src/main/resources/common.yml
+++ b/backend/src/main/resources/common.yml
@@ -8,6 +8,7 @@ springdoc:
     display-request-duration: true
     operations-sorter: alpha
     enabled: true
+    path: /swagger-ui.html
 
 odsay:
   url: https://api.odsay.com/v1/api/searchPubTransPathT

--- a/backend/src/main/resources/common.yml
+++ b/backend/src/main/resources/common.yml
@@ -10,6 +10,7 @@ springdoc:
     enabled: true
     path: /swagger-ui.html
 
+
 odsay:
   url: https://api.odsay.com/v1/api/searchPubTransPathT
   api-key: ENC(8A1VHDvR44k6DXfWB5oudFz9FH4a0ZtqK5bApHvyrWQHiFK13Z6ZeBxVGufZFbbaI/1etI1hSyE=)

--- a/backend/src/main/resources/common.yml
+++ b/backend/src/main/resources/common.yml
@@ -8,8 +8,6 @@ springdoc:
     display-request-duration: true
     operations-sorter: alpha
     enabled: true
-    path: /swagger-ui.html
-
 
 odsay:
   url: https://api.odsay.com/v1/api/searchPubTransPathT


### PR DESCRIPTION
# 🚩 연관 이슈 
close #544 


<br>

# 📝 작업 내용


무료로 발급 받은 DNS가 예정된 만료일 보다 빨리 만료되어 서버 접속이 불가했음.
=> 가비아에서 새로 발급한 oody.site 도메인으로 재등록하여 해결

추가로 애플리케이션 재실행마다 스케줄링 작업이 실행될 때 
findAllByTypeAndStatus()로 가져온 Notification 엔티티 내부의 엔티티들의 값에 접근할 때 
Lazy 예외가 발생하는 것이 문제였음.
<img width="809" alt="image" src="https://github.com/user-attachments/assets/1fe5f342-9a26-4fae-a57b-a05709940eb6">
=> findAllByTypeAndStatus()에 Fetch Join을 추가해 해결

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
