### PR TITLE
fix: 수도권 검증 로직에서 missing 좌표도 추가

### DIFF
--- a/backend/src/main/java/com/ody/common/validator/SupportRegionValidator.java
+++ b/backend/src/main/java/com/ody/common/validator/SupportRegionValidator.java
@@ -13,6 +13,7 @@ public class SupportRegionValidator implements ConstraintValidator<SupportRegion
     private static final BigDecimal MAX_LATITUDE = new BigDecimal("38.3");
     private static final BigDecimal MIN_LONGITUDE = new BigDecimal("125.6");
     private static final BigDecimal MAX_LONGITUDE = new BigDecimal("127.9");
+    private static final BigDecimal MISSING_COORDINATES = new BigDecimal("0.0");
 
     private String latitudeFieldName;
     private String longitudeFieldName;
@@ -41,11 +42,17 @@ public class SupportRegionValidator implements ConstraintValidator<SupportRegion
 
     private boolean isInLatitudeRange(String latitude) {
         BigDecimal latitudeValue = new BigDecimal(latitude);
-        return MIN_LATITUDE.compareTo(latitudeValue) <= 0 && MAX_LATITUDE.compareTo(latitudeValue) >= 0;
+        return isMissingCoordinate(latitudeValue)
+                || (MIN_LATITUDE.compareTo(latitudeValue) <= 0 && MAX_LATITUDE.compareTo(latitudeValue) >= 0);
     }
 
     private boolean isInLongitudeRange(String longitude) {
         BigDecimal longitudeValue = new BigDecimal(longitude);
-        return MIN_LONGITUDE.compareTo(longitudeValue) <= 0 && MAX_LONGITUDE.compareTo(longitudeValue) >= 0;
+        return isMissingCoordinate(longitudeValue)
+                || (MIN_LONGITUDE.compareTo(longitudeValue) <= 0 && MAX_LONGITUDE.compareTo(longitudeValue) >= 0);
+    }
+
+    private boolean isMissingCoordinate(BigDecimal coordinate) {
+        return MISSING_COORDINATES.compareTo(coordinate) == 0;
     }
 }

--- a/backend/src/test/java/com/ody/common/validator/SupportRegionValidatorTest.java
+++ b/backend/src/test/java/com/ody/common/validator/SupportRegionValidatorTest.java
@@ -11,6 +11,7 @@ import java.lang.annotation.Annotation;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,6 +35,16 @@ class SupportRegionValidatorTest {
         boolean valid = supportRegionValidator.isValid(mateEtaRequest, mock(ConstraintValidatorContext.class));
 
         assertThat(valid).isEqualTo(expected);
+    }
+
+    @DisplayName("행방불명 좌표(0.0)는 true를 반환한다")
+    @Test
+    void isValidMissingCoordinate() {
+        MateEtaRequest mateEtaRequest = new MateEtaRequest(false, "0.0", "0.0");
+
+        boolean valid = supportRegionValidator.isValid(mateEtaRequest, mock(ConstraintValidatorContext.class));
+
+        assertThat(valid).isEqualTo(true);
     }
 
     private static Stream<Arguments> supportRegionTestCases() {


### PR DESCRIPTION
# 🚩 연관 이슈 
close #601 


<br>

# 📝 작업 내용
- [ ] #601 
- 문제 원인 : 행방 불명 상태에서 request에 담아주는 0.0 좌표가 수도권 검증 로직에서 404반환
- 해결 방법 : 수도권 검증 로직에서 missingCoordinate인 0.0을 허용하도록 변경


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
