### PR TITLE
fix: ETA 공지 알림 오지 않는 문제 해결

### DIFF
--- a/backend/src/main/java/com/ody/notification/domain/FcmTopic.java
+++ b/backend/src/main/java/com/ody/notification/domain/FcmTopic.java
@@ -3,6 +3,7 @@ package com.ody.notification.domain;
 import com.ody.meeting.domain.Meeting;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import java.time.format.DateTimeFormatter;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class FcmTopic {
 
     private static final String TOPIC_NAME_DELIMITER = "_";
+    private static final DateTimeFormatter MEETING_CREATE_AT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     @Column(name = "fcm_topic")
     private String value;
@@ -28,6 +30,6 @@ public class FcmTopic {
     private static String build(Meeting meeting) {
         return meeting.getId().toString()
                 + TOPIC_NAME_DELIMITER
-                + meeting.getCreatedAt();
+                + meeting.getCreatedAt().format(MEETING_CREATE_AT_FORMAT);
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #609


<br>

# 📝 작업 내용
save() 시에 반환된 meeting 객체에서 createAt()을 가져올 경우 가공된 형식이 아닌 LocalDateTime의 기본 형식이 반환되는 문제로
같은 meeting으로 생성된 FcmTopic이라도 Mate 참여시에 생성된 FCM 토픽과 모임 생성시 생성된 FCM 토픽이 달라 알림이 가지 않았음.
`DateTimeFormatter`로 createAt() 형태를 고정해놓았음.

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
