### PR TITLE
hotfix: 약속방 로그가 뜨지 않는 문제 해결

### DIFF
--- a/backend/src/main/java/com/ody/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/ody/notification/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package com.ody.notification.repository;
 import com.ody.notification.domain.Notification;
 import com.ody.notification.domain.NotificationStatus;
 import com.ody.notification.domain.NotificationType;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -15,10 +16,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             from Notification noti
             left join fetch Mate m on noti.mate = m
             left join Meeting meet on m.meeting = meet
-            where meet.id = :meetingId and noti.sendAt <= now()
+            where meet.id = :meetingId and noti.sendAt <= :time
             order by noti.sendAt asc
             """)
-    List<Notification> findAllMeetingLogs(Long meetingId);
+    List<Notification> findAllMeetingLogsBeforeThanEqual(Long meetingId, LocalDateTime time);
 
     @Query("""
             select noti

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -92,7 +92,7 @@ public class NotificationService {
 
     @DisabledDeletedFilter
     public NotiLogFindResponses findAllMeetingLogs(Long meetingId) {
-        List<Notification> notifications = notificationRepository.findAllMeetingLogs(meetingId);
+        List<Notification> notifications = notificationRepository.findAllMeetingLogsBeforeThanEqual(meetingId, LocalDateTime.now());
         return NotiLogFindResponses.from(notifications);
     }
 

--- a/backend/src/test/java/com/ody/notification/repository/NotificationRepositoryTest.java
+++ b/backend/src/test/java/com/ody/notification/repository/NotificationRepositoryTest.java
@@ -49,7 +49,7 @@ class NotificationRepositoryTest extends BaseRepositoryTest {
         notificationRepository.save(notification1);
         notificationRepository.save(notification2);
 
-        List<Notification> notifications = notificationRepository.findAllMeetingLogs(odyMeeting.getId());
+        List<Notification> notifications = notificationRepository.findAllMeetingLogsBeforeThanEqual(odyMeeting.getId(), LocalDateTime.now());
 
         assertThat(notifications.size()).isEqualTo(2);
     }
@@ -86,7 +86,7 @@ class NotificationRepositoryTest extends BaseRepositoryTest {
         notificationRepository.save(pastNotification);
         notificationRepository.save(futureNotification);
 
-        List<Notification> notifications = notificationRepository.findAllMeetingLogs(odyMeeting.getId());
+        List<Notification> notifications = notificationRepository.findAllMeetingLogsBeforeThanEqual(odyMeeting.getId(), LocalDateTime.now());
 
         assertThat(notifications.size()).isOne();
     }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #606 


<br>

# 📝 작업 내용
- [ ] #606 
- 로그들을 가져오는 쿼리에서 now()가 UTC 기준으로 찍히는 문제 > 조회 기준점을 파라미터로 받게 수정

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
