### PR TITLE
hotfix: OSIV false 설정으로 인한 스케줄링 메서드 트랜잭션 선언

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -62,8 +62,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	compileOnly 'org.projectlombok:lombok'
 
-	implementation "org.flywaydb:flyway-mysql"
-	implementation "org.flywaydb:flyway-core"
+	implementation 'org.flywaydb:flyway-mysql'
+	implementation 'org.flywaydb:flyway-core'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -80,6 +80,7 @@ public class NotificationService {
         );
     }
 
+    @Transactional
     @EventListener(ApplicationReadyEvent.class)
     public void schedulePendingNotification() {
         List<Notification> notifications = notificationRepository.findAllByTypeAndStatus(
@@ -92,7 +93,10 @@ public class NotificationService {
 
     @DisabledDeletedFilter
     public NotiLogFindResponses findAllMeetingLogs(Long meetingId) {
-        List<Notification> notifications = notificationRepository.findAllMeetingLogsBeforeThanEqual(meetingId, LocalDateTime.now());
+        List<Notification> notifications = notificationRepository.findAllMeetingLogsBeforeThanEqual(
+                meetingId,
+                LocalDateTime.now()
+        );
         return NotiLogFindResponses.from(notifications);
     }
 


### PR DESCRIPTION
# 🚩 연관 이슈 
close #614 


<br>

# 📝 작업 내용

<img width="821" alt="image" src="https://github.com/user-attachments/assets/626a5cdb-4eda-47b1-bedc-7753e4fc17eb">

OSIV false 설정으로 인해 해당 메서드까지 영속성 컨텍스트가 살아있지 못해서 Lazy 예외가 발생
=> 트랜잭션 선언으로 영속성 컨텍스트 생명 범위 확장

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
