### PR TITLE
bugfix: READ, WRITE DB 선택 로그

### DIFF
--- a/backend/src/main/java/com/ody/common/config/ReplicationDataSourceRouter.java
+++ b/backend/src/main/java/com/ody/common/config/ReplicationDataSourceRouter.java
@@ -12,7 +12,7 @@ public class ReplicationDataSourceRouter extends AbstractRoutingDataSource {
         boolean isTransactionActive = TransactionSynchronizationManager.isActualTransactionActive();
         boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
         ReplicationType type = ReplicationType.from(isTransactionActive, readOnly);
-        log.info("(트랜잭션 활성화 여부 : {}) (readOnly : {}) => {} DB 연결", isTransactionActive, isTransactionActive, type);
+        log.info("(트랜잭션 활성화 여부 : {}) (readOnly : {}) => {} DB 연결", isTransactionActive, readOnly, type);
         return type;
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #620


<br>

# 📝 작업 내용

로그가 항상 `(트랜잭션 활성화 여부 : true) (readOnly : true)`로 떠서 확인해보니 변수가 제대로 안 들어가고 있었음

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
