### PR TITLE
chore: 안드로이드 cd 배포 위치 테스트 트랙에서 프로덕션 트랙으로 변경

### DIFF
--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -73,5 +73,5 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: com.mulberry.ody
           releaseFiles: /home/runner/work/2024-ody/2024-ody/android/app/build/outputs/bundle/release/app-release.aab
-          track: internal
-          status: draft
+          track: production
+          status: completed


### PR DESCRIPTION
# 🚩 연관 이슈 
close #624

<br>

# 📝 작업 내용
- [x] 안드로이드 cd 배포 위치 테스트 트랙에서 프로덕션 트랙으로 변경

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
