### PR TITLE
refactor: 초대코드 검증 시 참여여부 확인하도록 수정

### DIFF
--- a/backend/src/main/java/com/ody/mate/service/MateService.java
+++ b/backend/src/main/java/com/ody/mate/service/MateService.java
@@ -37,9 +37,7 @@ public class MateService {
             Member member,
             Meeting meeting
     ) {
-        if (mateRepository.existsByMeetingIdAndMemberId(meeting.getId(), member.getId())) {
-            throw new OdyBadRequestException("약속에 이미 참여한 회원입니다.");
-        }
+        validateAlreadyAttended(member, meeting);
         if (meeting.isOverdue()) {
             throw new OdyBadRequestException("참여 가능한 시간이 지난 약속에 참여할 수 없습니다.");
         }
@@ -47,6 +45,12 @@ public class MateService {
         Mate mate = saveMateAndEta(mateSaveRequest, member, meeting);
         notificationService.saveAndSendNotifications(meeting, mate, member.getDeviceToken());
         return MateSaveResponseV2.from(meeting);
+    }
+
+    public void validateAlreadyAttended(Member member, Meeting meeting) {
+        if (mateRepository.existsByMeetingIdAndMemberId(meeting.getId(), member.getId())) {
+            throw new OdyBadRequestException("약속에 이미 참여한 회원입니다.");
+        }
     }
 
     private Mate saveMateAndEta(MateSaveRequestV2 mateSaveRequest, Member member, Meeting meeting) {

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -78,7 +78,7 @@ public class MeetingController implements MeetingControllerSwagger {
             @AuthMember Member member,
             @PathVariable String inviteCode
     ) {
-        meetingService.findByInviteCode(inviteCode);
+        meetingService.validateInviteCode(member, inviteCode);
         return ResponseEntity.ok()
                 .build();
     }

--- a/backend/src/main/java/com/ody/meeting/service/MeetingService.java
+++ b/backend/src/main/java/com/ody/meeting/service/MeetingService.java
@@ -72,7 +72,12 @@ public class MeetingService {
         return inviteCode;
     }
 
-    public Meeting findByInviteCode(String inviteCode) {
+    public void validateInviteCode(Member member, String inviteCode) {
+        Meeting meeting = findByInviteCode(inviteCode);
+        mateService.validateAlreadyAttended(member, meeting);
+    }
+
+    private Meeting findByInviteCode(String inviteCode) {
         return meetingRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new OdyNotFoundException("존재하지 않는 초대코드입니다."));
     }

--- a/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
@@ -30,7 +30,6 @@ import com.ody.util.InviteCodeGenerator;
 import com.ody.util.TimeUtil;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -250,6 +249,25 @@ class MeetingServiceTest extends BaseServiceTest {
         MateSaveRequestV2 mateSaveRequest = makeMateRequestByMeeting(overdueMeeting);
 
         assertThatThrownBy(() -> meetingService.saveMateAndSendNotifications(mateSaveRequest, member))
+                .isInstanceOf(OdyBadRequestException.class);
+    }
+
+    @DisplayName("초대코드를 가진 약속을 찾을 수 없으면 404를 반환한다")
+    @Test
+    void validateInvitedCodeFailWhenNotExistsInviteCode() {
+        Member member = fixtureGenerator.generateMember();
+        assertThatThrownBy(() -> meetingService.validateInviteCode(member, "none"))
+                .isInstanceOf(OdyNotFoundException.class);
+    }
+
+    @DisplayName("이미 참여한 회원이 초대코드 검증을 요구하면 400을 반환한다")
+    @Test
+    void validateInviteCodeFailWhenAlreadyAttendedMeetingInviteCode() {
+        Member member = fixtureGenerator.generateMember();
+        Meeting meeting = fixtureGenerator.generateMeeting();
+        Mate mate = fixtureGenerator.generateMate(meeting, member);
+
+        assertThatThrownBy(() -> meetingService.validateInviteCode(member, meeting.getInviteCode()))
                 .isInstanceOf(OdyBadRequestException.class);
     }
 


### PR DESCRIPTION
# 🚩 연관 이슈 
close #643 


<br>

# 📝 작업 내용
- [ ] #643 
- 기존에는 모임 기참여자라도 초대코드가 유효하다면 200을 반환 > api 문서 스펙에 따라 참여했다면 400반환하도록 수정
![image](https://github.com/user-attachments/assets/083cebb1-e423-4b69-b4a7-c064242d94c8)


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
