### PR TITLE
fix: 재촉알림을 보낸 사람 기준으로 nudgeNotification이 저장되도록 수정 

### DIFF
--- a/backend/src/main/java/com/ody/notification/domain/Notification.java
+++ b/backend/src/main/java/com/ody/notification/domain/Notification.java
@@ -79,9 +79,9 @@ public class Notification extends BaseEntity {
         );
     }
 
-    public static Notification createNudge(Mate nudgeRequestMate) {
+    public static Notification createNudge(Mate requestMate) {
         return new Notification(
-                nudgeRequestMate,
+                requestMate,
                 NotificationType.NUDGE,
                 LocalDateTime.now(),
                 NotificationStatus.DONE,

--- a/backend/src/main/java/com/ody/notification/domain/Notification.java
+++ b/backend/src/main/java/com/ody/notification/domain/Notification.java
@@ -79,9 +79,9 @@ public class Notification extends BaseEntity {
         );
     }
 
-    public static Notification createNudge(Mate nudgeMate) {
+    public static Notification createNudge(Mate nudgeRequestMate) {
         return new Notification(
-                nudgeMate,
+                nudgeRequestMate,
                 NotificationType.NUDGE,
                 LocalDateTime.now(),
                 NotificationStatus.DONE,

--- a/backend/src/main/java/com/ody/notification/domain/message/DirectMessage.java
+++ b/backend/src/main/java/com/ody/notification/domain/message/DirectMessage.java
@@ -6,12 +6,12 @@ import com.ody.notification.domain.Notification;
 
 public record DirectMessage(Message message) {
 
-    public static DirectMessage createMessageToOther(Mate sender, Notification recipientNotification) {
+    public static DirectMessage createMessageToOther(Mate sender, Mate receiver, Notification recipientNotification) {
         Message message = Message.builder()
                 .putData("type", recipientNotification.getType().name())
                 .putData("nickname", sender.getNickname().getValue())
                 .putData("meetingId", sender.getMeeting().getId().toString())
-                .setToken(recipientNotification.getMate().getMember().getDeviceToken().getValue())
+                .setToken(receiver.getMember().getDeviceToken().getValue())
                 .build();
 
         return new DirectMessage(message);

--- a/backend/src/main/java/com/ody/notification/domain/message/DirectMessage.java
+++ b/backend/src/main/java/com/ody/notification/domain/message/DirectMessage.java
@@ -6,7 +6,8 @@ import com.ody.notification.domain.Notification;
 
 public record DirectMessage(Message message) {
 
-    public static DirectMessage createMessageToOther(Mate sender, Mate receiver, Notification recipientNotification) {
+    public static DirectMessage createMessageToOther(Mate receiver, Notification recipientNotification) {
+        Mate sender = recipientNotification.getMate();
         Message message = Message.builder()
                 .putData("type", recipientNotification.getType().name())
                 .putData("nickname", sender.getNickname().getValue())

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -105,7 +105,7 @@ public class NotificationService {
         Notification nudgeNotification = notificationRepository.save(Notification.createNudge(requestMate));
         fcmPushSender.sendNudgeMessage(
                 nudgeNotification,
-                DirectMessage.createMessageToOther(requestMate, nudgedMate, nudgeNotification)
+                DirectMessage.createMessageToOther(nudgedMate, nudgeNotification)
         );
     }
 

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -102,10 +102,10 @@ public class NotificationService {
 
     @Transactional
     public void sendNudgeMessage(Mate requestMate, Mate nudgedMate) {
-        Notification nudgeNotification = notificationRepository.save(Notification.createNudge(nudgedMate));
+        Notification nudgeNotification = notificationRepository.save(Notification.createNudge(requestMate));
         fcmPushSender.sendNudgeMessage(
                 nudgeNotification,
-                DirectMessage.createMessageToOther(requestMate, nudgeNotification)
+                DirectMessage.createMessageToOther(requestMate, nudgedMate, nudgeNotification)
         );
     }
 

--- a/backend/src/test/java/com/ody/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/ody/notification/service/NotificationServiceTest.java
@@ -163,7 +163,7 @@ class NotificationServiceTest extends BaseServiceTest {
 
     @DisplayName("재촉하기 메시지가 발송된다")
     @Test
-    void sendSendNudgeMessage() {
+    void sendNudgeMessage() {
         Member member1 = memberRepository.save(Fixture.MEMBER1);
         Member member2 = memberRepository.save(Fixture.MEMBER2);
         Meeting odyMeeting = meetingRepository.save(Fixture.ODY_MEETING);


### PR DESCRIPTION
# 🚩 연관 이슈 
close #670


<br>

# 📝 작업 내용
- [x] #670 

<br>

# 🏞️ 스크린샷 (선택)
ex)
재촉한 사람 : 방어진
재촉당한 사람: 김건우

**방어진이 재촉해요! 라는 메시지가 떠야 하는데 재촉당한 사람을 기준으로 로그 메시지가 구성됨**

![image](https://github.com/user-attachments/assets/456dab56-fa0d-4fcf-9689-443f4d306d78)

<br>

# 🗣️ 리뷰 요구사항 (선택)
