### PR TITLE
chore: dev 로그 미수집 원인 해결

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ody-dev-logs-vol:/ody-dev-logs
+      - /var/logs/ody-dev-logs:/ody-dev-logs
     platform: linux/arm64
     depends_on:
       db:
@@ -32,4 +32,3 @@ services:
 
 volumes:
   ody-dev-db-vol:
-  ody-dev-logs-vol:


### PR DESCRIPTION
# 🚩 연관 이슈 
close #673


<br>

# 📝 작업 내용

dev 서버에서만 docker 내 로그 파일에는 로그가 생기는데 EC2 내 로그 파일에는 업데이트가 안 되어서 
prod와 dev의 volume 설정 비교해봤습니다

```
docker inspect ody-***-app | grep -A 5 "Mounts"
```


### prod volume

```
        "Mounts": [
            {
                "Type": "bind",
                "Source": "/var/logs/ody-prod-logs",
                "Destination": "/ody-prod-logs",
                "Mode": "",
```

### dev volume

```
            "Mounts": [
                {
                    "Type": "volume",
                    "Source": "ubuntu_ody-dev-logs-vol",
                    "Target": "/ody-dev-logs",
                    "VolumeOptions": {}
--
        "Mounts": [
            {
                "Type": "volume",
                "Name": "ubuntu_ody-dev-logs-vol",
                "Source": "/var/lib/docker/volumes/ubuntu_ody-dev-logs-vol/_data",
                "Destination": "/ody-dev-logs",
```

<br>

Source를 확인해보면 지정하고자 한 경로가 아니라 EC2 내 로그 파일 업데이트가 안 되는 상황인 것 같아요
그래서 docker-compose.yml에서 수정을 해주었습니다~!

<br>

추가로, Type이 다른 게 궁금해서 찾아봤는데 volume과 bind mount가 다른 개념이네요!
volume은 docker가 관리하는 거고 일반적으로 /var/lib/docker/volumes/ 내에 위치하게 되는데,
bind mount는 호스트 파일 시스템의 특정 경로를 컨테이너에 직접 마운트하는 거라 호스트의 어느 위치든 가능합니다.
prod 로그가 잘 수집되고 있기도 하고, bind mount가 로그 파일 접근 목적으로는 더 적절한 것 같아요~

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
