### PR TITLE
design: 주소 입력 화면의 windowSoftInputMode 속성 추가

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,8 +37,7 @@
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
-            tools:node="remove">
-        </provider>
+            tools:node="remove" />
 
         <activity
             android:name=".presentation.splash.SplashActivity"
@@ -80,7 +79,8 @@
         <activity
             android:name=".presentation.join.MeetingJoinActivity"
             android:exported="false"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".presentation.join.complete.JoinCompleteActivity"
             android:exported="false"
@@ -92,7 +92,8 @@
         <activity
             android:name=".presentation.creation.MeetingCreationActivity"
             android:exported="false"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".presentation.room.MeetingRoomActivity"
             android:exported="false"


### PR DESCRIPTION
# 🚩 연관 이슈 
close #678 


<br>

# 📝 작업 내용


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
원래 출발지 입력 화면에서 주소 입력 Fragment 진입해서도 다음 버튼이 계속 남아있는 버그가 있었는데요!!
(play store에 올라간 앱 버전도 이 현상 존재함..)
현재 develop pull 받아서 다시 설치하니까 제 의도대로 다음 버튼이 없어졌더라구요 ㄷㄷ 나는 해결한 기억이 없는데.... 황당tv
그런데 키보드 올라올 때 주소 입력 Fragment의 사이즈도 변경되면 더 자연스러울 것 같아서, 그 속성만 추가해서 pr 올립니다!!