### PR TITLE
chore: android cd 트리거 브랜치 네임으로 변경

### DIFF
--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -2,9 +2,7 @@ name: android cd
 on:
   pull_request:
     branches:
-      - main
-    paths:
-      - android/**
+      - 'release-an/**'
     types:
       - closed
 


### PR DESCRIPTION
# 🚩 연관 이슈 
close #633



# 📝 작업 내용

- [x] android cd 트리거 브랜치 네임으로 변경

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
