### PR TITLE
feat: refresh token expiration 변경

### DIFF
--- a/backend/src/main/resources/common.yml
+++ b/backend/src/main/resources/common.yml
@@ -30,7 +30,7 @@ auth:
   access-key: ENC(jp1TJCM6l22zIzInTUvt9VXrb1WhNm1zY3dFgTSj6ad3585f5K7Q8A==)
   access-expiration: ENC(RA/POzGT/Baq/ba9MxmMAQ==)
   refresh-key: ENC(5uLKuwtNdyXnr61LRqQJ6Q2sfbhjW5vxgLADB4Na8YgoIkLvcmJk+A==)
-  refresh-expiration: ENC(LUMzldRJndHMoxKs+pyCF5J0MrT94NY+)
+  refresh-expiration: ENC(GU+tXC1UeXlXFBe9y6IOwnZFtwmRj/a2)
 
 fcm:
   config:


### PR DESCRIPTION
# 🚩 연관 이슈 
close #693


<br>

# 📝 작업 내용

차람의 요청에 따라 리프레시 토큰의 유효기간을 아래와 같이 수정합니다

| 기존 | 변경 |
| -- | -- |
| 86,400,000 = 60 * 60 * 24 (1일) | 2,419,200,000 = 86,400,000 * 7 * 4 (4주) |

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
