### PR TITLE
refactor: ViewModel의 LiveData를 Flow로 변경

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -138,6 +138,7 @@ dependencies {
     implementation(libs.play.services.location)
 
     // coroutines
+    implementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)
 
     // glide

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
@@ -5,6 +5,7 @@ import android.view.KeyEvent
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.mulberry.ody.R
 import com.mulberry.ody.databinding.FragmentAddressSearchBinding
 import com.mulberry.ody.presentation.address.adapter.AddressesAdapter
@@ -12,6 +13,7 @@ import com.mulberry.ody.presentation.address.listener.AddressSearchListener
 import com.mulberry.ody.presentation.common.binding.BindingFragment
 import com.mulberry.ody.presentation.common.listener.BackListener
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class AddressSearchFragment :
@@ -69,16 +71,24 @@ class AddressSearchFragment :
             showRetrySnackBar { viewModel.retryLastAction() }
         }
 
-        viewModel.addressUiModels.observe(viewLifecycleOwner) {
-            adapter.submitList(it)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.addressUiModels.collect {
+                adapter.submitList(it)
+            }
         }
-        viewModel.addressSelectEvent.observe(viewLifecycleOwner) {
-            (parentFragment as? AddressSearchListener)?.onReceive(it)
-            (activity as? AddressSearchListener)?.onReceive(it)
-            onBack()
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.addressSelectEvent.collect {
+                (parentFragment as? AddressSearchListener)?.onReceive(it)
+                (activity as? AddressSearchListener)?.onReceive(it)
+                onBack()
+            }
         }
-        viewModel.addressSearchKeyword.observe(viewLifecycleOwner) {
-            if (it.isEmpty()) viewModel.clearAddresses()
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.addressSearchKeyword.collect {
+                if (it.isEmpty()) viewModel.clearAddresses()
+            }
         }
     }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
@@ -50,7 +50,7 @@ class AddressSearchViewModel
         val addressUiModels: StateFlow<List<AddressUiModel>> =
             addresses.map { it.toAddressUiModels() }.stateIn(
                 scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
+                started = SharingStarted.Eagerly,
                 initialValue = emptyList(),
             )
 
@@ -62,7 +62,7 @@ class AddressSearchViewModel
         }
 
         fun searchAddress() {
-            val addressSearchKeyword = addressSearchKeyword.value ?: return
+            val addressSearchKeyword = addressSearchKeyword.value
             if (addressSearchKeyword.isEmpty()) return
 
             viewModelScope.launch {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
@@ -1,8 +1,5 @@
 package com.mulberry.ody.presentation.address
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.mulberry.ody.domain.apiresult.onFailure
 import com.mulberry.ody.domain.apiresult.onNetworkError
@@ -13,11 +10,17 @@ import com.mulberry.ody.presentation.address.listener.AddressListener
 import com.mulberry.ody.presentation.address.model.AddressUiModel
 import com.mulberry.ody.presentation.address.model.toAddressUiModels
 import com.mulberry.ody.presentation.common.BaseViewModel
-import com.mulberry.ody.presentation.common.MutableSingleLiveData
-import com.mulberry.ody.presentation.common.SingleLiveData
 import com.mulberry.ody.presentation.common.analytics.AnalyticsHelper
 import com.mulberry.ody.presentation.common.analytics.logNetworkErrorEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -29,15 +32,30 @@ class AddressSearchViewModel
         private val analyticsHelper: AnalyticsHelper,
         private val addressRepository: AddressRepository,
     ) : BaseViewModel(), AddressListener {
-        val addressSearchKeyword: MutableLiveData<String> = MutableLiveData()
-        val hasAddressSearchKeyword: LiveData<Boolean> = addressSearchKeyword.map { it.isNotEmpty() }
+        val addressSearchKeyword: MutableStateFlow<String> = MutableStateFlow("")
+        val hasAddressSearchKeyword: StateFlow<Boolean> =
+            addressSearchKeyword.map { it.isNotEmpty() }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = false,
+            )
 
-        private val addresses: MutableLiveData<List<Address>> = MutableLiveData(emptyList())
-        val isEmptyAddresses: LiveData<Boolean> = addresses.map { it.isEmpty() }
-        val addressUiModels: LiveData<List<AddressUiModel>> = addresses.map { it.toAddressUiModels() }
+        private val addresses: MutableStateFlow<List<Address>> = MutableStateFlow(emptyList())
+        val isEmptyAddresses: StateFlow<Boolean> =
+            addresses.map { it.isEmpty() }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = true,
+            )
+        val addressUiModels: StateFlow<List<AddressUiModel>> =
+            addresses.map { it.toAddressUiModels() }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = emptyList(),
+            )
 
-        private val _addressSelectEvent: MutableSingleLiveData<Address> = MutableSingleLiveData()
-        val addressSelectEvent: SingleLiveData<Address> get() = _addressSelectEvent
+        private val _addressSelectEvent: MutableSharedFlow<Address> = MutableSharedFlow()
+        val addressSelectEvent: SharedFlow<Address> get() = _addressSelectEvent.asSharedFlow()
 
         fun clearAddressSearchKeyword() {
             addressSearchKeyword.value = ""
@@ -65,7 +83,9 @@ class AddressSearchViewModel
 
         override fun onClickAddressItem(id: Long) {
             val address = addresses.value?.find { it.id == id } ?: return
-            _addressSelectEvent.setValue(address)
+            viewModelScope.launch {
+                _addressSelectEvent.emit(address)
+            }
         }
 
         fun clearAddresses() {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
@@ -36,7 +36,7 @@ class AddressSearchViewModel
         val hasAddressSearchKeyword: StateFlow<Boolean> =
             addressSearchKeyword.map { it.isNotEmpty() }.stateIn(
                 scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
+                started = SharingStarted.WhileSubscribed(STATE_FLOW_SUBSCRIPTION_TIMEOUT_MILLIS),
                 initialValue = false,
             )
 
@@ -44,7 +44,7 @@ class AddressSearchViewModel
         val isEmptyAddresses: StateFlow<Boolean> =
             addresses.map { it.isEmpty() }.stateIn(
                 scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
+                started = SharingStarted.WhileSubscribed(STATE_FLOW_SUBSCRIPTION_TIMEOUT_MILLIS),
                 initialValue = true,
             )
         val addressUiModels: StateFlow<List<AddressUiModel>> =
@@ -94,6 +94,8 @@ class AddressSearchViewModel
 
         companion object {
             private const val TAG = "AddressSearchViewModel"
+
             private const val PAGE_SIZE = 10
+            private const val STATE_FLOW_SUBSCRIPTION_TIMEOUT_MILLIS = 5000L
         }
     }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
+import androidx.lifecycle.lifecycleScope
 import com.mulberry.ody.R
 import com.mulberry.ody.databinding.ActivityMeetingCreationBinding
 import com.mulberry.ody.domain.model.Address
@@ -21,6 +22,7 @@ import com.mulberry.ody.presentation.creation.name.MeetingNameFragment
 import com.mulberry.ody.presentation.creation.time.MeetingTimeFragment
 import com.mulberry.ody.presentation.join.MeetingJoinActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MeetingCreationActivity :
@@ -65,21 +67,27 @@ class MeetingCreationActivity :
 
     private fun initializeObserve() {
         onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
-        viewModel.inviteCode.observe(this) {
-            viewModel.onClickCreationMeeting()
+        lifecycleScope.launch {
+            viewModel.inviteCode.collect {
+                viewModel.onClickCreationMeeting()
+            }
         }
-        viewModel.nextPageEvent.observe(this) {
-            handleMeetingInfoNextClick()
+        lifecycleScope.launch {
+            viewModel.nextPageEvent.collect {
+                handleMeetingInfoNextClick()
+            }
         }
-        viewModel.navigateAction.observe(this) {
-            when (it) {
-                MeetingCreationNavigateAction.NavigateToMeetings -> {
-                    finish()
-                }
+        lifecycleScope.launch {
+            viewModel.navigateAction.collect {
+                when (it) {
+                    MeetingCreationNavigateAction.NavigateToMeetings -> {
+                        finish()
+                    }
 
-                is MeetingCreationNavigateAction.NavigateToMeetingJoin -> {
-                    startActivity(MeetingJoinActivity.getIntent(it.inviteCode, this))
-                    finish()
+                    is MeetingCreationNavigateAction.NavigateToMeetingJoin -> {
+                        startActivity(MeetingJoinActivity.getIntent(it.inviteCode, this@MeetingCreationActivity))
+                        finish()
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
@@ -53,8 +53,8 @@ class MeetingCreationViewModel
         private val _invalidMeetingDateEvent = MutableSharedFlow<Unit>()
         val invalidMeetingDateEvent: SharedFlow<Unit> = _invalidMeetingDateEvent
 
-        val meetingHour = MutableStateFlow<Int?>(null)
-        val meetingMinute = MutableStateFlow<Int?>(null)
+        val meetingHour = MutableStateFlow(-1)
+        val meetingMinute = MutableStateFlow(-1)
 
         private val _invalidMeetingTimeEvent = MutableSharedFlow<Unit>()
         val invalidMeetingTimeEvent: SharedFlow<Unit> = _invalidMeetingTimeEvent
@@ -70,8 +70,13 @@ class MeetingCreationViewModel
         private val _navigateAction = MutableSharedFlow<MeetingCreationNavigateAction>()
         val navigateAction: SharedFlow<MeetingCreationNavigateAction> = _navigateAction
 
-        private val _inviteCode = MutableStateFlow<String?>(null)
-        val inviteCode: StateFlow<String?> = _inviteCode
+        private val _inviteCode = MutableStateFlow("")
+        val inviteCode: StateFlow<String> = _inviteCode
+
+        init {
+            Timber.i("$_inviteCode")
+            Timber.i("$inviteCode")
+        }
 
         init {
             initializeIsValidInfo()
@@ -94,7 +99,7 @@ class MeetingCreationViewModel
         }
 
         fun initializeMeetingTime() {
-            if (meetingHour.value != null || meetingMinute.value != null) {
+            if (meetingHour.value != -1 || meetingMinute.value != -1) {
                 return
             }
             val now = LocalTime.now()
@@ -125,8 +130,13 @@ class MeetingCreationViewModel
         private fun createMeetingCreationInfo(): MeetingCreationInfo? {
             val name = meetingName.value.ifBlank { return null }
             val date = meetingDate.value ?: return null
-            val hour = meetingHour.value ?: return null
-            val minute = meetingMinute.value ?: return null
+
+            val hour = meetingHour.value
+            val minute = meetingMinute.value
+
+            if (meetingHour.value == -1) return null
+            if (meetingMinute.value == -1) return null
+
             val address = destinationAddress.value ?: return null
 
             return MeetingCreationInfo(
@@ -199,7 +209,9 @@ class MeetingCreationViewModel
         }
 
         override fun onClickCreationMeeting() {
-            val inviteCode = _inviteCode.value ?: return
+            val inviteCode = _inviteCode.value
+            if (inviteCode.isBlank()) return
+
             viewModelScope.launch {
                 _navigateAction.emit(
                     MeetingCreationNavigateAction.NavigateToMeetingJoin(inviteCode),

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -51,32 +53,27 @@ class MeetingCreationViewModel
         val meetingDate = MutableStateFlow(LocalDate.now())
 
         private val _invalidMeetingDateEvent = MutableSharedFlow<Unit>()
-        val invalidMeetingDateEvent: SharedFlow<Unit> = _invalidMeetingDateEvent
+        val invalidMeetingDateEvent: SharedFlow<Unit> = _invalidMeetingDateEvent.asSharedFlow()
 
         val meetingHour = MutableStateFlow(-1)
         val meetingMinute = MutableStateFlow(-1)
 
         private val _invalidMeetingTimeEvent = MutableSharedFlow<Unit>()
-        val invalidMeetingTimeEvent: SharedFlow<Unit> = _invalidMeetingTimeEvent
+        val invalidMeetingTimeEvent: SharedFlow<Unit> = _invalidMeetingTimeEvent.asSharedFlow()
 
         val destinationAddress = MutableStateFlow<Address?>(null)
 
         private val _invalidDestinationEvent = MutableSharedFlow<Unit>()
-        val invalidDestinationEvent: SharedFlow<Unit> = _invalidDestinationEvent
+        val invalidDestinationEvent: SharedFlow<Unit> = _invalidDestinationEvent.asSharedFlow()
 
         private val _nextPageEvent = MutableSharedFlow<Unit>()
-        val nextPageEvent: SharedFlow<Unit> = _nextPageEvent
+        val nextPageEvent: SharedFlow<Unit> = _nextPageEvent.asSharedFlow()
 
         private val _navigateAction = MutableSharedFlow<MeetingCreationNavigateAction>()
-        val navigateAction: SharedFlow<MeetingCreationNavigateAction> = _navigateAction
+        val navigateAction: SharedFlow<MeetingCreationNavigateAction> = _navigateAction.asSharedFlow()
 
         private val _inviteCode = MutableStateFlow("")
-        val inviteCode: StateFlow<String> = _inviteCode
-
-        init {
-            Timber.i("$_inviteCode")
-            Timber.i("$inviteCode")
-        }
+        val inviteCode: StateFlow<String> = _inviteCode.asStateFlow()
 
         init {
             initializeIsValidInfo()

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
@@ -119,7 +119,7 @@ class MeetingCreationViewModel
         }
 
         private fun createMeetingCreationInfo(): MeetingCreationInfo? {
-            val name = meetingName.value.takeIf { it.isNotEmpty() } ?: return null
+            val name = meetingName.value.ifBlank { return null }
             val date = meetingDate.value ?: return null
             val hour = meetingHour.value ?: return null
             val minute = meetingMinute.value ?: return null

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
@@ -55,8 +55,8 @@ class MeetingCreationViewModel
         private val _invalidMeetingDateEvent = MutableSharedFlow<Unit>()
         val invalidMeetingDateEvent: SharedFlow<Unit> = _invalidMeetingDateEvent.asSharedFlow()
 
-        val meetingHour = MutableStateFlow(-1)
-        val meetingMinute = MutableStateFlow(-1)
+        val meetingHour = MutableStateFlow(MEETING_HOUR_DEFAULT_VALUE)
+        val meetingMinute = MutableStateFlow(MEETING_MINUTE_DEFAULT_VALUE)
 
         private val _invalidMeetingTimeEvent = MutableSharedFlow<Unit>()
         val invalidMeetingTimeEvent: SharedFlow<Unit> = _invalidMeetingTimeEvent.asSharedFlow()
@@ -96,9 +96,7 @@ class MeetingCreationViewModel
         }
 
         fun initializeMeetingTime() {
-            if (meetingHour.value != -1 || meetingMinute.value != -1) {
-                return
-            }
+            if (meetingHour.value != MEETING_HOUR_DEFAULT_VALUE || meetingMinute.value != MEETING_MINUTE_DEFAULT_VALUE) return
             val now = LocalTime.now()
             meetingHour.value = now.hour
             meetingMinute.value = now.minute
@@ -223,5 +221,7 @@ class MeetingCreationViewModel
             val MEETING_MINUTES = (0..<60).toList()
             const val MEETING_NAME_MAX_LENGTH = 15
             private const val STATE_FLOW_SUBSCRIPTION_TIMEOUT_MILLIS = 5000L
+            private const val MEETING_HOUR_DEFAULT_VALUE = -1
+            private const val MEETING_MINUTE_DEFAULT_VALUE = -1
         }
     }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
@@ -37,8 +37,7 @@ class MeetingCreationViewModel
     ) : BaseViewModel(), MeetingCreationListener {
         val meetingCreationInfoType = MutableStateFlow<MeetingCreationInfoType?>(null)
 
-        private val _isValidInfo = MutableStateFlow(false)
-        val isValidInfo: StateFlow<Boolean> = _isValidInfo
+        val isValidInfo = MutableStateFlow(false)
 
         val meetingName: MutableStateFlow<String> = MutableStateFlow("")
         val meetingNameLength: StateFlow<Int> =
@@ -85,7 +84,7 @@ class MeetingCreationViewModel
                 ) { _, _, _, _, _ ->
                     checkInfoValidity()
                 }.collect { isValid ->
-                    _isValidInfo.value = isValid
+                    isValidInfo.value = isValid
                 }
             }
         }
@@ -181,7 +180,7 @@ class MeetingCreationViewModel
 
         fun moveOnNextPage() {
             viewModelScope.launch {
-                if (_isValidInfo.value) {
+                if (isValidInfo.value) {
                     _nextPageEvent.emit(Unit)
                 } else if (meetingCreationInfoType.value == MeetingCreationInfoType.TIME) {
                     _invalidMeetingTimeEvent.emit(Unit)

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
@@ -42,7 +42,11 @@ class MeetingCreationViewModel
         val meetingName: MutableStateFlow<String> = MutableStateFlow("")
         val meetingNameLength: StateFlow<Int> =
             meetingName.map { it.length }
-                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
+                .stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(STATE_FLOW_SUBSCRIPTION_TIMEOUT_MILLIS),
+                    0,
+                )
 
         val meetingDate = MutableStateFlow(LocalDate.now())
 
@@ -209,5 +213,6 @@ class MeetingCreationViewModel
             val MEETING_HOURS = (0..<24).toList()
             val MEETING_MINUTES = (0..<60).toList()
             const val MEETING_NAME_MAX_LENGTH = 15
+            private const val STATE_FLOW_SUBSCRIPTION_TIMEOUT_MILLIS = 5000L
         }
     }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/date/MeetingDateFragment.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/date/MeetingDateFragment.kt
@@ -3,11 +3,13 @@ package com.mulberry.ody.presentation.creation.date
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import com.mulberry.ody.R
 import com.mulberry.ody.databinding.FragmentMeetingDateBinding
 import com.mulberry.ody.presentation.common.binding.BindingFragment
 import com.mulberry.ody.presentation.creation.MeetingCreationInfoType
 import com.mulberry.ody.presentation.creation.MeetingCreationViewModel
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 
 class MeetingDateFragment :
@@ -41,14 +43,16 @@ class MeetingDateFragment :
     }
 
     private fun initializeObserve() {
-        viewModel.invalidMeetingDateEvent.observe(viewLifecycleOwner) {
-            showSnackBar(R.string.meeting_date_date_guide)
-            val meetingDate = viewModel.meetingDate.value ?: return@observe
-            binding.dpDate.updateDate(
-                meetingDate.year,
-                meetingDate.monthValue - 1,
-                meetingDate.dayOfMonth,
-            )
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.invalidMeetingDateEvent.collect {
+                showSnackBar(R.string.meeting_date_date_guide)
+                val meetingDate = viewModel.meetingDate.value
+                binding.dpDate.updateDate(
+                    meetingDate.year,
+                    meetingDate.monthValue - 1,
+                    meetingDate.dayOfMonth,
+                )
+            }
         }
     }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/destination/MeetingDestinationFragment.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/destination/MeetingDestinationFragment.kt
@@ -3,12 +3,14 @@ package com.mulberry.ody.presentation.creation.destination
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import com.mulberry.ody.R
 import com.mulberry.ody.databinding.FragmentMeetingDestinationBinding
 import com.mulberry.ody.presentation.address.listener.AddressSearchListener
 import com.mulberry.ody.presentation.common.binding.BindingFragment
 import com.mulberry.ody.presentation.creation.MeetingCreationInfoType
 import com.mulberry.ody.presentation.creation.MeetingCreationViewModel
+import kotlinx.coroutines.launch
 
 class MeetingDestinationFragment :
     BindingFragment<FragmentMeetingDestinationBinding>(
@@ -31,8 +33,10 @@ class MeetingDestinationFragment :
     }
 
     private fun initializeObserve() {
-        viewModel.invalidDestinationEvent.observe(viewLifecycleOwner) {
-            showSnackBar(R.string.invalid_address)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.invalidDestinationEvent.collect {
+                showSnackBar(R.string.invalid_address)
+            }
         }
     }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/time/MeetingTimeFragment.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/time/MeetingTimeFragment.kt
@@ -3,11 +3,13 @@ package com.mulberry.ody.presentation.creation.time
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import com.mulberry.ody.R
 import com.mulberry.ody.databinding.FragmentMeetingTimeBinding
 import com.mulberry.ody.presentation.common.binding.BindingFragment
 import com.mulberry.ody.presentation.creation.MeetingCreationInfoType
 import com.mulberry.ody.presentation.creation.MeetingCreationViewModel
+import kotlinx.coroutines.launch
 
 class MeetingTimeFragment : BindingFragment<FragmentMeetingTimeBinding>(R.layout.fragment_meeting_time) {
     private val viewModel: MeetingCreationViewModel by activityViewModels<MeetingCreationViewModel>()
@@ -27,8 +29,10 @@ class MeetingTimeFragment : BindingFragment<FragmentMeetingTimeBinding>(R.layout
     }
 
     private fun initializeObserve() {
-        viewModel.invalidMeetingTimeEvent.observe(viewLifecycleOwner) {
-            showSnackBar(R.string.invalid_meeting_time)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.invalidMeetingTimeEvent.collect {
+                showSnackBar(R.string.invalid_meeting_time)
+            }
         }
     }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginActivity.kt
@@ -4,11 +4,13 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.mulberry.ody.R
 import com.mulberry.ody.databinding.ActivityLoginBinding
 import com.mulberry.ody.presentation.common.binding.BindingActivity
 import com.mulberry.ody.presentation.meetings.MeetingsActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_login) {
@@ -26,19 +28,23 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
     }
 
     private fun initializeObserve() {
-        viewModel.navigatedReason.observe(this) {
-            when (it) {
-                LoginNavigatedReason.LOGOUT -> {
-                    showSnackBar(R.string.login_logout_success)
-                }
-                LoginNavigatedReason.WITHDRAWAL -> {
-                    showSnackBar(R.string.login_withdrawal_success)
+        lifecycleScope.launch {
+            viewModel.navigatedReason.collect {
+                when (it) {
+                    LoginNavigatedReason.LOGOUT -> {
+                        showSnackBar(R.string.login_logout_success)
+                    }
+                    LoginNavigatedReason.WITHDRAWAL -> {
+                        showSnackBar(R.string.login_withdrawal_success)
+                    }
                 }
             }
         }
-        viewModel.navigateAction.observe(this) {
-            val intent = MeetingsActivity.getIntent(this@LoginActivity)
-            startActivity(intent)
+        lifecycleScope.launch {
+            viewModel.navigateAction.collect {
+                val intent = MeetingsActivity.getIntent(this@LoginActivity)
+                startActivity(intent)
+            }
         }
         viewModel.networkErrorEvent.observe(this) {
             showRetrySnackBar { viewModel.retryLastAction() }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginViewModel.kt
@@ -8,11 +8,12 @@ import com.mulberry.ody.domain.apiresult.onNetworkError
 import com.mulberry.ody.domain.apiresult.onSuccess
 import com.mulberry.ody.domain.repository.ody.LoginRepository
 import com.mulberry.ody.presentation.common.BaseViewModel
-import com.mulberry.ody.presentation.common.MutableSingleLiveData
-import com.mulberry.ody.presentation.common.SingleLiveData
 import com.mulberry.ody.presentation.common.analytics.AnalyticsHelper
 import com.mulberry.ody.presentation.common.analytics.logNetworkErrorEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -24,17 +25,19 @@ class LoginViewModel
         private val loginRepository: LoginRepository,
         private val savedStateHandle: SavedStateHandle,
     ) : BaseViewModel() {
-        private val _navigatedReason: MutableSingleLiveData<LoginNavigatedReason> =
-            MutableSingleLiveData()
-        val navigatedReason: SingleLiveData<LoginNavigatedReason> get() = _navigatedReason
+        private val _navigatedReason: MutableSharedFlow<LoginNavigatedReason> =
+            MutableSharedFlow()
+        val navigatedReason: SharedFlow<LoginNavigatedReason> get() = _navigatedReason.asSharedFlow()
 
-        private val _navigateAction: MutableSingleLiveData<LoginNavigateAction> =
-            MutableSingleLiveData()
-        val navigateAction: SingleLiveData<LoginNavigateAction> get() = _navigateAction
+        private val _navigateAction: MutableSharedFlow<LoginNavigateAction> =
+            MutableSharedFlow()
+        val navigateAction: SharedFlow<LoginNavigateAction> get() = _navigateAction.asSharedFlow()
 
         fun checkIfNavigated() {
             savedStateHandle.get<LoginNavigatedReason>(NAVIGATED_REASON)?.let { reason ->
-                _navigatedReason.setValue(reason)
+                viewModelScope.launch {
+                    _navigatedReason.emit(reason)
+                }
             }
         }
 
@@ -64,7 +67,9 @@ class LoginViewModel
         }
 
         private fun navigateToMeetings() {
-            _navigateAction.setValue(LoginNavigateAction.NavigateToMeetings)
+            viewModelScope.launch {
+                _navigateAction.emit(LoginNavigateAction.NavigateToMeetings)
+            }
         }
 
         companion object {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.widget.LinearLayout
 import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.mulberry.ody.BuildConfig
 import com.mulberry.ody.R
@@ -19,6 +20,7 @@ import com.mulberry.ody.presentation.setting.listener.SettingListener
 import com.mulberry.ody.presentation.setting.model.SettingUiModel
 import com.mulberry.ody.presentation.setting.withdrawal.WithDrawalDialog
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class SettingActivity :
@@ -35,14 +37,16 @@ class SettingActivity :
     }
 
     private fun initializeObserve() {
-        viewModel.loginNavigateEvent.observe(this) {
-            when (it) {
-                LoginNavigatedReason.LOGOUT -> {
-                    navigateToLogin()
-                }
+        lifecycleScope.launch {
+            viewModel.loginNavigateEvent.collect {
+                when (it) {
+                    LoginNavigatedReason.LOGOUT -> {
+                        navigateToLogin()
+                    }
 
-                LoginNavigatedReason.WITHDRAWAL -> {
-                    navigateToWithdrawal()
+                    LoginNavigatedReason.WITHDRAWAL -> {
+                        navigateToWithdrawal()
+                    }
                 }
             }
         }

--- a/android/app/src/test/java/com/mulberry/ody/presentation/address/AddressSearchViewModelTest.kt
+++ b/android/app/src/test/java/com/mulberry/ody/presentation/address/AddressSearchViewModelTest.kt
@@ -6,8 +6,8 @@ import com.mulberry.ody.fake.FakeAnalyticsHelper
 import com.mulberry.ody.presentation.address.model.toAddressUiModels
 import com.mulberry.ody.util.CoroutinesTestExtension
 import com.mulberry.ody.util.InstantTaskExecutorExtension
-import com.mulberry.ody.util.getOrAwaitValue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -29,15 +29,17 @@ class AddressSearchViewModelTest {
     }
 
     @Test
-    fun `주소에 대한 위경도를 받아온다`() {
-        // given
-        viewModel.addressSearchKeyword.value = "사당역"
+    fun `주소에 대한 위경도를 받아온다`() =
+        runTest {
+            // given
+            viewModel.addressSearchKeyword.value = "사당역"
 
-        // when
-        viewModel.searchAddress()
+            // when
+            viewModel.searchAddress()
 
-        // then
-        val actual = viewModel.addressUiModels.getOrAwaitValue()
-        assertThat(actual).isEqualTo(addresses.toAddressUiModels())
-    }
+            // then
+            val actual = viewModel.addressUiModels.value
+
+            assertThat(actual).isEqualTo(addresses.toAddressUiModels())
+        }
 }

--- a/android/app/src/test/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModelTest.kt
+++ b/android/app/src/test/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModelTest.kt
@@ -158,7 +158,7 @@ class MeetingCreationViewModelTest {
 
         // when
         viewModel.meetingDate.value = LocalDate.of(2023, 7, 28)
-        viewModel.meetingHour.value = 18
+        viewModel.meetingHour.value = 17
         viewModel.meetingMinute.value = 0
 
         // then

--- a/android/app/src/test/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModelTest.kt
+++ b/android/app/src/test/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModelTest.kt
@@ -147,7 +147,7 @@ class MeetingCreationViewModelTest {
 
         // then
         val actual = viewModel.isValidInfo.value
-        assertThat(actual).isTrue()
+        assertThat(actual).isTrue
     }
 
     @Test

--- a/android/app/src/test/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModelTest.kt
+++ b/android/app/src/test/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModelTest.kt
@@ -7,7 +7,6 @@ import com.mulberry.ody.fake.FakeMeetingRepository
 import com.mulberry.ody.inviteCode
 import com.mulberry.ody.util.CoroutinesTestExtension
 import com.mulberry.ody.util.InstantTaskExecutorExtension
-import com.mulberry.ody.util.getOrAwaitValue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -40,8 +39,8 @@ class MeetingCreationViewModelTest {
         viewModel.initializeMeetingTime()
 
         // then
-        val hour = viewModel.meetingHour.getOrAwaitValue()
-        val minute = viewModel.meetingMinute.getOrAwaitValue()
+        val hour = viewModel.meetingHour.value
+        val minute = viewModel.meetingMinute.value
         assertThat(hour).isEqualTo(nowTime.hour)
         assertThat(minute).isEqualTo(nowTime.minute)
     }
@@ -55,7 +54,7 @@ class MeetingCreationViewModelTest {
         viewModel.createMeeting()
 
         // then
-        val actual = viewModel.inviteCode.getOrAwaitValue()
+        val actual = viewModel.inviteCode.value
         assertThat(actual).isEqualTo(inviteCode)
     }
 
@@ -65,7 +64,7 @@ class MeetingCreationViewModelTest {
         viewModel.createMeeting()
 
         // then
-        assertThat(viewModel.inviteCode.isInitialized).isFalse
+        assertThat(viewModel.inviteCode.value)
     }
 
     @Test
@@ -78,7 +77,7 @@ class MeetingCreationViewModelTest {
         viewModel.meetingName.value = "카키와 술 먹기"
 
         // then
-        val actual = viewModel.isValidInfo.getOrAwaitValue()
+        val actual = viewModel.isValidInfo.value
         assertThat(actual).isTrue
     }
 
@@ -92,7 +91,7 @@ class MeetingCreationViewModelTest {
         viewModel.meetingName.value = "카키와 술 먹기 카키와 술 먹기 카키와 술 먹기"
 
         // then
-        val actual = viewModel.isValidInfo.getOrAwaitValue()
+        val actual = viewModel.isValidInfo.value
         assertThat(actual).isFalse
     }
 
@@ -105,7 +104,7 @@ class MeetingCreationViewModelTest {
         viewModel.updateMeetingDate(meetingDate)
 
         // then
-        val actual = viewModel.invalidMeetingDateEvent.getValue()
+        val actual = viewModel.invalidMeetingDateEvent
         assertThat(actual).isNotNull
     }
 
@@ -118,7 +117,7 @@ class MeetingCreationViewModelTest {
         viewModel.updateMeetingDate(meetingDate)
 
         // then
-        val actual = viewModel.meetingDate.getOrAwaitValue()
+        val actual = viewModel.meetingDate.value
         assertThat(actual).isEqualTo(LocalDate.now())
     }
 
@@ -131,7 +130,7 @@ class MeetingCreationViewModelTest {
         viewModel.updateMeetingDate(meetingDate)
 
         // then
-        val actual = viewModel.meetingDate.getOrAwaitValue()
+        val actual = viewModel.meetingDate.value
         assertThat(actual).isEqualTo(LocalDate.of(2030, 7, 28))
     }
 
@@ -147,8 +146,8 @@ class MeetingCreationViewModelTest {
         viewModel.meetingMinute.value = 0
 
         // then
-        val actual = viewModel.isValidInfo.getOrAwaitValue()
-        assertThat(actual).isTrue
+        val actual = viewModel.isValidInfo.value
+        assertThat(actual).isTrue()
     }
 
     @Test
@@ -163,7 +162,7 @@ class MeetingCreationViewModelTest {
         viewModel.meetingMinute.value = 0
 
         // then
-        val actual = viewModel.isValidInfo.getOrAwaitValue()
+        val actual = viewModel.isValidInfo.value
         assertThat(actual).isFalse
     }
 
@@ -177,7 +176,7 @@ class MeetingCreationViewModelTest {
         viewModel.destinationAddress.value = Address(0, "인천광역시 남동구")
 
         // then
-        val actual = viewModel.isValidInfo.getOrAwaitValue()
+        val actual = viewModel.isValidInfo.value
         assertThat(actual).isTrue
     }
 
@@ -191,7 +190,7 @@ class MeetingCreationViewModelTest {
         viewModel.destinationAddress.value = Address(0, "부산광역시 동구")
 
         // then
-        val actual = viewModel.isValidInfo.getOrAwaitValue()
+        val actual = viewModel.isValidInfo.value
         assertThat(actual).isFalse
     }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ appcompat = "1.7.0"
 assertj = "3.25.3"
 constraintlayout = "2.1.4"
 coreKtx = "1.13.1"
+coroutine = "1.9.0"
 coroutinesTest = "1.9.0-RC"
 datastoreCoreAndroid = "1.1.1"
 datastorePreferences = "1.1.1"
@@ -109,6 +110,7 @@ logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", ver
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
 
 # coroutines
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutine" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 
 # kakao sdk


### PR DESCRIPTION
# 🚩 연관 이슈 
close #640 


<br>

# 📝 작업 내용
- [x] AddressSearchViewModel
- [x] MeetingCreationViewModel 
- [x] LoginViewModel
- [x] SettingViewModel

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
- MutableLiveData -> MutableStateFlow
- LiveData -> StateFlow
- MediatorLivedata -> combine
- MutableSingleLiveData -> MutableSharedFlow
- SingleLiveData -> SharedFlow

Flow로 다 마이그레이션 하면 MutableSingleLiveData 지워야 합니다!