### PR TITLE
feat: 웹소켓 에러 핸들러 구현

### DIFF
--- a/backend/src/main/java/com/ody/common/exception/OdyException.java
+++ b/backend/src/main/java/com/ody/common/exception/OdyException.java
@@ -8,7 +8,7 @@ public abstract class OdyException extends RuntimeException {
 
     private final HttpStatus httpStatus;
 
-    public OdyException(String message, HttpStatus httpStatus) {
+    protected OdyException(String message, HttpStatus httpStatus) {
         super(message);
         this.httpStatus = httpStatus;
     }

--- a/backend/src/main/java/com/ody/common/exception/OdyWebSocketException.java
+++ b/backend/src/main/java/com/ody/common/exception/OdyWebSocketException.java
@@ -1,0 +1,8 @@
+package com.ody.common.exception;
+
+public class OdyWebSocketException extends RuntimeException {
+
+    public OdyWebSocketException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/ody/eta/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/ody/eta/config/WebSocketConfig.java
@@ -25,7 +25,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/topic");
+        registry.enableSimpleBroker("/topic", "/queue");
         registry.setApplicationDestinationPrefixes("/publish");
     }
 

--- a/backend/src/main/java/com/ody/eta/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/ody/eta/config/WebSocketConfig.java
@@ -1,24 +1,36 @@
 package com.ody.eta.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketPreHandler webSocketPreHandler;
+    private final WebSocketErrorHandler webSocketErrorHandler;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/connect")
                 .setAllowedOrigins("*");
+        registry.setErrorHandler(webSocketErrorHandler);
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic");
         registry.setApplicationDestinationPrefixes("/publish");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketPreHandler);
     }
 }

--- a/backend/src/main/java/com/ody/eta/config/WebSocketErrorHandler.java
+++ b/backend/src/main/java/com/ody/eta/config/WebSocketErrorHandler.java
@@ -1,6 +1,5 @@
 package com.ody.eta.config;
 
-import com.ody.common.exception.OdyException;
 import com.ody.common.exception.OdyWebSocketException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
@@ -23,21 +22,14 @@ public class WebSocketErrorHandler extends StompSubProtocolErrorHandler {
             log.warn("message: {}", message);
             return createErrorMessage(message);
         }
-
-        if (cause instanceof OdyException) {
-            log.warn("message: {}", message);
-            return createErrorMessage(message);
-        }
-
-        if (cause instanceof Exception) {
-            log.error("exception: {}", cause);
-            return createErrorMessage("서버 에러");
-        }
         return super.handleClientMessageProcessingError(clientMessage, ex);
     }
 
     private Message<byte[]> createErrorMessage(String exceptionMessage) {
         StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+        accessor.setMessage(exceptionMessage);
+        accessor.setLeaveMutable(true);
+
         return MessageBuilder.createMessage(exceptionMessage.getBytes(), accessor.getMessageHeaders());
     }
 }

--- a/backend/src/main/java/com/ody/eta/config/WebSocketErrorHandler.java
+++ b/backend/src/main/java/com/ody/eta/config/WebSocketErrorHandler.java
@@ -1,0 +1,43 @@
+package com.ody.eta.config;
+
+import com.ody.common.exception.OdyException;
+import com.ody.common.exception.OdyWebSocketException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+@Slf4j
+@Configuration
+public class WebSocketErrorHandler extends StompSubProtocolErrorHandler {
+
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+        Throwable cause = ex.getCause();
+        String message = cause.getMessage();
+
+        if (cause instanceof OdyWebSocketException) {
+            log.warn("message: {}", message);
+            return createErrorMessage(message);
+        }
+
+        if (cause instanceof OdyException) {
+            log.warn("message: {}", message);
+            return createErrorMessage(message);
+        }
+
+        if (cause instanceof Exception) {
+            log.error("exception: {}", cause);
+            return createErrorMessage("서버 에러");
+        }
+        return super.handleClientMessageProcessingError(clientMessage, ex);
+    }
+
+    private Message<byte[]> createErrorMessage(String exceptionMessage) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+        return MessageBuilder.createMessage(exceptionMessage.getBytes(), accessor.getMessageHeaders());
+    }
+}

--- a/backend/src/main/java/com/ody/eta/config/WebSocketPreHandler.java
+++ b/backend/src/main/java/com/ody/eta/config/WebSocketPreHandler.java
@@ -1,0 +1,43 @@
+package com.ody.eta.config;
+
+import com.ody.common.exception.OdyWebSocketException;
+import com.ody.eta.domain.WebSocketEndpoint;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+
+@Configuration
+public class WebSocketPreHandler implements ChannelInterceptor {
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        StompCommand command = accessor.getCommand();
+        String destination = accessor.getDestination();
+
+        if (StompCommand.SUBSCRIBE.equals(command)) {
+            validateSubscribeEndpoint(destination);
+        }
+        if (StompCommand.SEND.equals(command)) {
+            validateSendEndpoint(destination);
+        }
+        return message;
+    }
+
+    private void validateSubscribeEndpoint(String destination) {
+        if (WebSocketEndpoint.getSubscribeEndpoints().contains(destination)) {
+            return;
+        }
+        throw new OdyWebSocketException(destination + "은 유효하지 않은 subscribe endpoint 입니다.");
+    }
+
+    private void validateSendEndpoint(String destination) {
+        if (WebSocketEndpoint.getSendEndpoints().contains(destination)) {
+            return;
+        }
+        throw new OdyWebSocketException(destination + "은 유효하지 않은 send endpoint 입니다.");
+    }
+}

--- a/backend/src/main/java/com/ody/eta/controller/EtaSocketController.java
+++ b/backend/src/main/java/com/ody/eta/controller/EtaSocketController.java
@@ -1,5 +1,6 @@
 package com.ody.eta.controller;
 
+import com.ody.common.exception.OdyException;
 import com.ody.eta.annotation.WebSocketAuthMember;
 import com.ody.eta.dto.request.MateEtaRequest;
 import com.ody.eta.service.EtaSocketService;
@@ -7,10 +8,14 @@ import com.ody.meeting.dto.response.MateEtaResponsesV2;
 import com.ody.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -35,5 +40,19 @@ public class EtaSocketController {
     ) {
         log.info("--- etaUpdate 호출 ! - {}, {}, {}", meetingId, member, etaRequest);
         return etaSocketService.etaUpdate(meetingId, member, etaRequest);
+    }
+
+    @MessageExceptionHandler
+    @SendToUser("/queue/errors")
+    public ProblemDetail handleOdyException(OdyException exception) {
+        log.warn("exception: ", exception);
+        return ProblemDetail.forStatusAndDetail(exception.getHttpStatus(), exception.getMessage());
+    }
+
+    @MessageExceptionHandler
+    @SendToUser("/queue/errors")
+    public ProblemDetail handleException(Exception exception) {
+        log.error("exception: ", exception);
+        return ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러");
     }
 }

--- a/backend/src/main/java/com/ody/eta/domain/WebSocketEndpoint.java
+++ b/backend/src/main/java/com/ody/eta/domain/WebSocketEndpoint.java
@@ -2,25 +2,26 @@ package com.ody.eta.domain;
 
 import java.util.Arrays;
 import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@Getter
+@RequiredArgsConstructor
 public enum WebSocketEndpoint {
 
     OPEN("/publish/open/"),
     ETA_UPDATE("/publish/etas/"),
     ETAS("/topic/etas/"),
     LOCATION("/topic/coordinates/"),
-    DISCONNECT( "/topic/disconnect/"),
+    DISCONNECT("/topic/disconnect/"),
+    ERROR("/user/queue/errors"),
     ;
 
     private final String endpoint;
 
-    WebSocketEndpoint(String endpoint) {
-        this.endpoint = endpoint;
-    }
-
     public static List<String> getSubscribeEndpoints() {
         return Arrays.stream(values()).map(value -> value.endpoint)
-                .filter(endpoint -> endpoint.startsWith("/topic/"))
+                .filter(endpoint -> endpoint.startsWith("/topic/") || endpoint.contains("/queue/"))
                 .toList();
     }
 
@@ -28,9 +29,5 @@ public enum WebSocketEndpoint {
         return Arrays.stream(values()).map(value -> value.endpoint)
                 .filter(endpoint -> endpoint.startsWith("/publish/"))
                 .toList();
-    }
-
-    public String getEndpoint() {
-        return endpoint;
     }
 }

--- a/backend/src/main/java/com/ody/eta/domain/WebSocketEndpoint.java
+++ b/backend/src/main/java/com/ody/eta/domain/WebSocketEndpoint.java
@@ -29,4 +29,8 @@ public enum WebSocketEndpoint {
                 .filter(endpoint -> endpoint.startsWith("/publish/"))
                 .toList();
     }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
 }

--- a/backend/src/main/java/com/ody/eta/domain/WebSocketEndpoint.java
+++ b/backend/src/main/java/com/ody/eta/domain/WebSocketEndpoint.java
@@ -1,0 +1,32 @@
+package com.ody.eta.domain;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum WebSocketEndpoint {
+
+    OPEN("/publish/open/"),
+    ETA_UPDATE("/publish/etas/"),
+    ETAS("/topic/etas/"),
+    LOCATION("/topic/coordinates/"),
+    DISCONNECT( "/topic/disconnect/"),
+    ;
+
+    private final String endpoint;
+
+    WebSocketEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public static List<String> getSubscribeEndpoints() {
+        return Arrays.stream(values()).map(value -> value.endpoint)
+                .filter(endpoint -> endpoint.startsWith("/topic/"))
+                .toList();
+    }
+
+    public static List<String> getSendEndpoints() {
+        return Arrays.stream(values()).map(value -> value.endpoint)
+                .filter(endpoint -> endpoint.startsWith("/publish/"))
+                .toList();
+    }
+}

--- a/backend/src/test/java/com/ody/common/websocket/BaseStompTest.java
+++ b/backend/src/test/java/com/ody/common/websocket/BaseStompTest.java
@@ -60,8 +60,7 @@ public class BaseStompTest {
     @BeforeEach
     public void connect() throws ExecutionException, InterruptedException, TimeoutException {
         this.stompSession = this.websocketClient
-                .connect(url + port + ENDPOINT, new StompSessionHandlerAdapter() {
-                })
+                .connect(url + port + ENDPOINT, new StompSessionHandlerAdapter() {})
                 .get(3, TimeUnit.SECONDS);
     }
 

--- a/backend/src/test/java/com/ody/common/websocket/MessageFrameHandler.java
+++ b/backend/src/test/java/com/ody/common/websocket/MessageFrameHandler.java
@@ -24,8 +24,7 @@ public class MessageFrameHandler<T> implements StompFrameHandler {
 
     @Override
     public void handleFrame(StompHeaders headers, Object payload) {
-        if (completableFuture.complete((T) payload)) {
-        }
+        completableFuture.complete((T) payload);
     }
 
     public CompletableFuture<T> getCompletableFuture() {

--- a/backend/src/test/java/com/ody/eta/domain/WebSocketEndpointTest.java
+++ b/backend/src/test/java/com/ody/eta/domain/WebSocketEndpointTest.java
@@ -15,7 +15,8 @@ class WebSocketEndpointTest {
         List<String> expected = List.of(
                 WebSocketEndpoint.ETAS.getEndpoint(),
                 WebSocketEndpoint.LOCATION.getEndpoint(),
-                WebSocketEndpoint.DISCONNECT.getEndpoint()
+                WebSocketEndpoint.DISCONNECT.getEndpoint(),
+                WebSocketEndpoint.ERROR.getEndpoint()
         );
 
         assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);

--- a/backend/src/test/java/com/ody/eta/domain/WebSocketEndpointTest.java
+++ b/backend/src/test/java/com/ody/eta/domain/WebSocketEndpointTest.java
@@ -1,0 +1,35 @@
+package com.ody.eta.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WebSocketEndpointTest {
+
+    @DisplayName("subscribe endpoint 리스트를 반환한다.")
+    @Test
+    void getSubscribeEndpoints() {
+        List<String> actual = WebSocketEndpoint.getSubscribeEndpoints();
+        List<String> expected = List.of(
+                WebSocketEndpoint.ETAS.getEndpoint(),
+                WebSocketEndpoint.LOCATION.getEndpoint(),
+                WebSocketEndpoint.DISCONNECT.getEndpoint()
+        );
+
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @DisplayName("send endpoint 리스트를 반환한다.")
+    @Test
+    void getSendEndpoint() {
+        List<String> actual = WebSocketEndpoint.getSendEndpoints();
+        List<String> expected = List.of(
+                WebSocketEndpoint.OPEN.getEndpoint(),
+                WebSocketEndpoint.ETA_UPDATE.getEndpoint()
+        );
+
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+    }
+}


### PR DESCRIPTION
# 🚩 연관 이슈 
close #538

536 브랜치에서 파생하여 작업 진행해서, 536으로 머지 요청해요.
<br>

# 📝 작업 내용
우선, 웹소켓 도입 여부가 확실치 않은 상황이지만 최후의 보루(?)가 될 수 있어서 구현했습니다.

controller에 들어오기 전(1), 후(2)에서 에러 핸들링 처리 구현했습니다.

### 1. Interceptor에서 endpoint 유효성 검사 (`WebSocketPreHandler`)
  - 실패 시 `OdyWebSocketException` 발생 -> `WebSocketErrorHandler`에서 에러를 캐치해 -> error message 생성

### 2. controller 내부 MessageExceptionHandler 구현 (`EtaSocketController`)
  - controller 진입 이후 에러 발생 시 -> ProblemDetail 객체 만들어 -> 요청을 보낸 user의 `/queue/errors`로 메시지 보냄

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
(2)번에 대한 테스트는 작성이 되었으나, (1)번 테스트는 검증의 어려움으로 구현하지 못했습니다..
검증하려고 한 부분은 `WebSocketPreHandler`의 `preSend()` 동작입니다. endpoint 검증하고 실패 시 `OdyWebSocketException` 던지는지 확인하려고 했어요.
[ChannelInterceptorTest](https://github.com/spring-projects/spring-integration/blob/main/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ChannelInterceptorTests.java#L290) 참고하여 `QueueChannel` 사용한 테스트 시도해보았으나, 임의로 생성한 Message 캐스팅이 잘 되지 않았어요. `StompHeaderAccessor` 모킹을 하면 될까 싶었는데 정팩메를 쓰고 있어서 불가능했구요.

우선, 다른 이슈들이 우선순위가 높다고 생각해 PR 올립니다.