### PR TITLE
chore: 무중단 배포 적용

### DIFF
--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-push:
-    if: github.event.pull_request.merged == true
+#    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,15 +1,11 @@
-
 name: backend-cd-prod
 
 on:
-  push:
+  pull_request:
     branches:
-      - feature/646
-#  pull_request:
-#    branches:
-#      - 'release-be/**'
-#    types:
-#      - closed
+      - 'release-be/**'
+    types:
+      - closed
 
 env:
   DOCKERHUB_REPOSITORY: ody-official
@@ -17,7 +13,7 @@ env:
 
 jobs:
   build-and-push:
-#    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     defaults:
@@ -26,8 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-#        with:
-#          ref: main
+        with:
+          ref: main
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,3 +1,4 @@
+
 name: backend-cd-prod
 
 on:
@@ -88,13 +89,16 @@ jobs:
           docker run -d --platform linux/arm64 --name $DOCKER_CONTAINER_NAME -v /var/logs/ody-prod-logs:/ody-prod-logs -p 80:8080 -e SPRING_PROFILES_ACTIVE=prod -e JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_PASSWORD }} ${{ secrets.DOCKERHUB_USERNAME }}/$DOCKERHUB_REPOSITORY:${{ github.sha }}-prod
 
       - name: Container Health Check
+        id: ody-prod-app-container
         uses: stringbean/docker-healthcheck-action@v1
         with:
-          container: $DOCKER_CONTAINER_NAME
+          container: ody-prod-app
           wait-time: 50
           require-status: running
           require-healthy: true
         continue-on-error: true
+
+      - run: echo "Container is ${{ steps.ody-prod-app-container.outputs.status  }}"
 
       - name: Check Docker Process
         run: docker ps

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,8 +1,10 @@
+
 name: backend-cd-prod
 
 on:
   push:
-    - feature/646
+    branches:
+      - feature/646
 #  pull_request:
 #    branches:
 #      - 'release-be/**'

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,11 +1,13 @@
 name: backend-cd-prod
 
 on:
-  pull_request:
-    branches:
-      - 'release-be/**'
-    types:
-      - closed
+  push:
+    - feature/646
+#  pull_request:
+#    branches:
+#      - 'release-be/**'
+#    types:
+#      - closed
 
 env:
   DOCKERHUB_REPOSITORY: ody-official
@@ -13,7 +15,7 @@ env:
 
 jobs:
   build-and-push:
-    if: github.event.pull_request.merged == true
+#    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     defaults:
@@ -22,8 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: main
+#        with:
+#          ref: main
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,11 +1,10 @@
+
 name: backend-cd-prod
 
 on:
-  pull_request:
+  push:
     branches:
-      - 'release-be/**'
-    types:
-      - closed
+      - feature/646
 
 env:
   DOCKERHUB_REPOSITORY: ody-official
@@ -69,7 +68,7 @@ jobs:
     strategy:
       max-parallel: 1 # 직렬처리
       matrix:
-        environment: [ prod, prod-a, prod-b ]
+        environment: [ prod-a, prod-b ]
 
     steps:
       - name: Login to Docker Hub
@@ -88,6 +87,15 @@ jobs:
           docker stop $DOCKER_CONTAINER_NAME || true
           docker rm $DOCKER_CONTAINER_NAME || true     
           docker run -d --platform linux/arm64 --name $DOCKER_CONTAINER_NAME -v /var/logs/ody-prod-logs:/ody-prod-logs -p 80:8080 -e SPRING_PROFILES_ACTIVE=prod -e JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_PASSWORD }} ${{ secrets.DOCKERHUB_USERNAME }}/$DOCKERHUB_REPOSITORY:${{ github.sha }}-prod
+
+      - name: Container Health Check
+        uses: stringbean/docker-healthcheck-action@v1
+        with:
+          container: $DOCKER_CONTAINER_NAME
+          wait-time: 50
+          require-status: running
+          require-healthy: true
+        continue-on-error: true
 
       - name: Check Docker Process
         run: docker ps

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,3 +1,4 @@
+
 name: backend-cd-prod
 
 on:
@@ -84,7 +85,10 @@ jobs:
       - name: Set up Container And Run Docker Image
         run: |
           docker stop $DOCKER_CONTAINER_NAME || true
-          docker rm $DOCKER_CONTAINER_NAME || true     
+          docker rm $DOCKER_CONTAINER_NAME || true
+          
+          sleep 20
+          
           docker run -d --platform linux/arm64 --name $DOCKER_CONTAINER_NAME -v /var/logs/ody-prod-logs:/ody-prod-logs -p 80:8080 -e SPRING_PROFILES_ACTIVE=prod -e JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_PASSWORD }} ${{ secrets.DOCKERHUB_USERNAME }}/$DOCKERHUB_REPOSITORY:${{ github.sha }}-prod
 
       - name: Health Check with Retry

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,5 +1,4 @@
 
-
 name: backend-cd-prod
 
 on:
@@ -98,6 +97,7 @@ jobs:
             MAX_RETRIES=5
             RETRY_DELAY=10
             
+            echo "-----헬스 체크 전-----"
             for i in $(seq 1 $MAX_RETRIES)
             do
               response=$(curl -s https://prod.oody.site/actuator/health)
@@ -115,6 +115,7 @@ jobs:
                 sleep $RETRY_DELAY
               fi
             done
+            echo "-----헬스 체크 후------"
         continue-on-error: true
 
       - name: Check Docker Process

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,4 +1,3 @@
-
 name: backend-cd-prod
 
 on:
@@ -21,8 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: main
+#        with:
+#          ref: main
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,10 +1,11 @@
-
 name: backend-cd-prod
 
 on:
-  push:
+  pull_request:
     branches:
-      - feature/646
+      - 'release-be/**'
+    types:
+      - closed
 
 env:
   DOCKERHUB_REPOSITORY: ody-official
@@ -12,7 +13,7 @@ env:
 
 jobs:
   build-and-push:
-#    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     defaults:
@@ -21,8 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-#        with:
-#          ref: main
+        with:
+          ref: main
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -96,8 +97,6 @@ jobs:
           command: |
             MAX_RETRIES=5
             RETRY_DELAY=10
-            
-            echo "-----헬스 체크 전-----"
             for i in $(seq 1 $MAX_RETRIES)
             do
               response=$(curl -s https://prod.oody.site/actuator/health)
@@ -106,7 +105,7 @@ jobs:
                 echo "Status is UP. Continuing..."
                 exit 0
               else
-                echo "Attempt $i: Status is not UP. Current status: $status"
+                echo "Attempt $i: Status is NOT UP. Current status: $status"
                 if [ $i -eq $MAX_RETRIES ]; then
                   echo "Max retries reached. Failing the job."
                   exit 1
@@ -115,7 +114,6 @@ jobs:
                 sleep $RETRY_DELAY
               fi
             done
-            echo "-----헬스 체크 후------"
         continue-on-error: true
 
       - name: Check Docker Process

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,4 +1,5 @@
 
+
 name: backend-cd-prod
 
 on:
@@ -85,10 +86,7 @@ jobs:
       - name: Set up Container And Run Docker Image
         run: |
           docker stop $DOCKER_CONTAINER_NAME || true
-          docker rm $DOCKER_CONTAINER_NAME || true
-          
-          sleep 20
-          
+          docker rm $DOCKER_CONTAINER_NAME || true          
           docker run -d --platform linux/arm64 --name $DOCKER_CONTAINER_NAME -v /var/logs/ody-prod-logs:/ody-prod-logs -p 80:8080 -e SPRING_PROFILES_ACTIVE=prod -e JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_PASSWORD }} ${{ secrets.DOCKERHUB_USERNAME }}/$DOCKERHUB_REPOSITORY:${{ github.sha }}-prod
 
       - name: Health Check with Retry
@@ -117,6 +115,7 @@ jobs:
                 sleep $RETRY_DELAY
               fi
             done
+        continue-on-error: true
 
       - name: Check Docker Process
         run: docker ps

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -93,28 +93,19 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 1
-          max_attempts: 3
+          max_attempts: 5
+          retry_wait_seconds: 6
           command: |
-            MAX_RETRIES=5
-            RETRY_DELAY=10
-            for i in $(seq 1 $MAX_RETRIES)
-            do
-              response=$(curl -s https://prod.oody.site/actuator/health)
-              status=$(echo $response | jq -r '.status')
-              if [ "$status" = "UP" ]; then
-                echo "Status is UP. Continuing..."
-                exit 0
-              else
-                echo "Attempt $i: Status is NOT UP. Current status: $status"
-                if [ $i -eq $MAX_RETRIES ]; then
-                  echo "Max retries reached. Failing the job."
-                  exit 1
-                fi
-                echo "Retrying in $RETRY_DELAY seconds..."
-                sleep $RETRY_DELAY
-              fi
-            done
-        continue-on-error: true
+            response=$(curl -s https://prod.oody.site/actuator/health)
+            status=$(echo $response | jq -r '.status')
+            if [ "$status" = "UP" ]; then
+              echo "Status is UP. Continuing..."
+              exit 0
+            else
+              echo "Status is NOT UP."
+              exit 1
+            fi
+        continue-on-error: true # 실패하면 롤백 필요함 (현재는 다음 작업으로 넘어가게함)
 
       - name: Check Docker Process
         run: docker ps

--- a/.github/workflows/backend-cd-prod.yml
+++ b/.github/workflows/backend-cd-prod.yml
@@ -1,4 +1,3 @@
-
 name: backend-cd-prod
 
 on:
@@ -88,17 +87,32 @@ jobs:
           docker rm $DOCKER_CONTAINER_NAME || true     
           docker run -d --platform linux/arm64 --name $DOCKER_CONTAINER_NAME -v /var/logs/ody-prod-logs:/ody-prod-logs -p 80:8080 -e SPRING_PROFILES_ACTIVE=prod -e JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_PASSWORD }} ${{ secrets.DOCKERHUB_USERNAME }}/$DOCKERHUB_REPOSITORY:${{ github.sha }}-prod
 
-      - name: Container Health Check
-        id: ody-prod-app-container
-        uses: stringbean/docker-healthcheck-action@v1
+      - name: Health Check with Retry
+        uses: nick-invision/retry@v2
         with:
-          container: ody-prod-app
-          wait-time: 50
-          require-status: running
-          require-healthy: true
-        continue-on-error: true
-
-      - run: echo "Container is ${{ steps.ody-prod-app-container.outputs.status  }}"
+          timeout_minutes: 1
+          max_attempts: 3
+          command: |
+            MAX_RETRIES=5
+            RETRY_DELAY=10
+            
+            for i in $(seq 1 $MAX_RETRIES)
+            do
+              response=$(curl -s https://prod.oody.site/actuator/health)
+              status=$(echo $response | jq -r '.status')
+              if [ "$status" = "UP" ]; then
+                echo "Status is UP. Continuing..."
+                exit 0
+              else
+                echo "Attempt $i: Status is not UP. Current status: $status"
+                if [ $i -eq $MAX_RETRIES ]; then
+                  echo "Max retries reached. Failing the job."
+                  exit 1
+                fi
+                echo "Retrying in $RETRY_DELAY seconds..."
+                sleep $RETRY_DELAY
+              fi
+            done
 
       - name: Check Docker Process
         run: docker ps

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -5,12 +5,12 @@ spring:
   datasource:
     write:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: jdbc:mysql://database-project.cluster-cqsc6pyqhwww.ap-northeast-2.rds.amazonaws.com:3306/ody
+      jdbc-url: jdbc:mysql://database-project.cluster-cqsc6pyqhwww.ap-northeast-2.rds.amazonaws.com:3306/od
       username: ody
       password: ENC(2n3gUzzFjknXpHDYwuF4d5BQw6XqLdsX)
     read:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: jdbc:mysql://database-project.cluster-ro-cqsc6pyqhwww.ap-northeast-2.rds.amazonaws.com:3306/ody
+      jdbc-url: jdbc:mysql://database-project.cluster-ro-cqsc6pyqhwww.ap-northeast-2.rds.amazonaws.com:3306/od
       username: ody
       password: ENC(2n3gUzzFjknXpHDYwuF4d5BQw6XqLdsX)
 

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -5,12 +5,12 @@ spring:
   datasource:
     write:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: jdbc:mysql://database-project.cluster-cqsc6pyqhwww.ap-northeast-2.rds.amazonaws.com:3306/od
+      jdbc-url: jdbc:mysql://database-project.cluster-cqsc6pyqhwww.ap-northeast-2.rds.amazonaws.com:3306/ody
       username: ody
       password: ENC(2n3gUzzFjknXpHDYwuF4d5BQw6XqLdsX)
     read:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: jdbc:mysql://database-project.cluster-ro-cqsc6pyqhwww.ap-northeast-2.rds.amazonaws.com:3306/od
+      jdbc-url: jdbc:mysql://database-project.cluster-ro-cqsc6pyqhwww.ap-northeast-2.rds.amazonaws.com:3306/ody
       username: ody
       password: ENC(2n3gUzzFjknXpHDYwuF4d5BQw6XqLdsX)
 

--- a/backend/src/main/resources/common.yml
+++ b/backend/src/main/resources/common.yml
@@ -1,3 +1,6 @@
+server:
+  shutdown: graceful
+
 spring:
   jpa:
     open-in-view: false


### PR DESCRIPTION
# 🚩 연관 이슈 
close #646 


<br>

# 📝 작업 내용
## 무중단 배포 전략
- Rolling : 실행중인 서버들을 점진적으로 신버전으로 교체
![img](https://github.com/user-attachments/assets/e8f819d4-4932-4a3f-9a90-9e257534409a)
[출처](https://ksh-coding.tistory.com/119)

## 선택 이유
1. 문제 발생 시 롤백이 간편하다.
2. 별도의 추가 EC2 자원이 필요하지 않다.
3. 서버가 2대에서 변동 가능성이 거의 없다.
4. blue green 전략을 고려했으나, AWS 오토 스케일링 권한이 없어 도입할 수 없고, Nginx도 고려했으나 네트워크 통신 단계가 많아 비효율적으로 판단했다.
- 서비스에 신버전, 구버전이 공존하기 때문에 균일한 서비스를 제공하지 못한다는 단점이 있지만, 2개의 자원만 가동하므로 큰 문제가 되지 않는다고 판단했음.

## 구현 방법
- cd 파이프라인에서 ec2 직렬로 이미지 run 후, 기존 구현되어 있던 `actuator/health` api 사용하여 헬스체크
- 헬스체크에 실패하면 다음 작업으로 넘어가도록 우선 구현해 둠 -> 롤백 구현하면서 개선해야 하는 포인트

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
