### PR TITLE
fix: 새벽 4시에 약속 삭제 로직 Lazy 에러 해결

### DIFF
--- a/backend/src/main/java/com/ody/meeting/service/MeetingService.java
+++ b/backend/src/main/java/com/ody/meeting/service/MeetingService.java
@@ -82,7 +82,7 @@ public class MeetingService {
                 .orElseThrow(() -> new OdyNotFoundException("존재하지 않는 초대코드입니다."));
     }
 
-    public Meeting findById(Long meetingId) {
+    public Meeting findByIdAndOverdueFalse(Long meetingId) {
         return meetingRepository.findByIdAndOverdueFalse(meetingId)
                 .orElseThrow(() -> new OdyNotFoundException("존재하지 않는 약속입니다."));
     }
@@ -105,7 +105,7 @@ public class MeetingService {
     }
 
     public MeetingWithMatesResponse findMeetingWithMates(Member member, Long meetingId) {
-        Meeting meeting = findById(meetingId);
+        Meeting meeting = findByIdAndOverdueFalse(meetingId);
         List<Mate> mates = mateService.findAllByMeetingIdIfMate(member, meeting.getId());
         return MeetingWithMatesResponse.of(meeting, mates);
     }

--- a/backend/src/main/java/com/ody/meeting/service/MeetingService.java
+++ b/backend/src/main/java/com/ody/meeting/service/MeetingService.java
@@ -119,6 +119,7 @@ public class MeetingService {
         return mateService.saveAndSendNotifications(mateSaveRequest, member, meeting);
     }
 
+    @Transactional
     @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
     public void scheduleOverdueMeetings() {
         meetingRepository.updateAllByNotOverdueMeetings();


### PR DESCRIPTION
# 🚩 연관 이슈 
close #700 


<br>

# 📝 작업 내용
새벽 4시마다 실행되는 scheduleOverdueMeetings() 메서드도 이전 스케줄링 문제와 동일하게
OSIV false로 Lazy 문제가 발생해 트랜잭션 범위에 넣어주어 해결했습니다.

추가로 4시마다 스케줄링된다는 부분을 테스트 추가했는데
현재는 실제 실행되는 상황과 동일하게 맞춰 테스트를 하지만
실제 스케줄링된 작업에 대한 테스트를 보장하진 않기 때문에 정책이 4시가 아닌 다른 시간으로 변경되면 테스트가 애매하긴해요
하지만 실제 스케줄링된 작업을 테스트하기 위해선 특정 시간만큼 기다리는 방법밖에 없는 것 같아 이 방법으로 추가해봤습니다

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
