### PR TITLE
design: 9인치, 12인치 화면에서 DatePicker, TimePicker 크기 수정

### DIFF
--- a/android/app/src/main/res/layout-sw1080dp/fragment_meeting_date.xml
+++ b/android/app/src/main/res/layout-sw1080dp/fragment_meeting_date.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.creation.date.MeetingDateFragment">
+
+        <TextView
+            android:id="@+id/tv_when"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="52dp"
+            android:text="@string/meeting_date_question_front"
+            android:textColor="@color/purple_800"
+            app:layout_constraintEnd_toStartOf="@+id/tv_meet"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_meet"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="@string/meeting_date_question_back"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_when"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/tv_when"
+            app:layout_constraintTop_toTopOf="@+id/tv_when" />
+
+        <DatePicker
+            android:id="@+id/dp_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:scaleX="2.0"
+            android:scaleY="2.0"
+            android:layout_marginHorizontal="@dimen/page_horizontal_margin"
+            android:layout_marginTop="300dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_meet" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout-sw1080dp/fragment_meeting_date.xml
+++ b/android/app/src/main/res/layout-sw1080dp/fragment_meeting_date.xml
@@ -40,7 +40,7 @@
             android:scaleX="2.0"
             android:scaleY="2.0"
             android:layout_marginHorizontal="@dimen/page_horizontal_margin"
-            android:layout_marginTop="300dp"
+            android:layout_marginTop="324dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_meet" />

--- a/android/app/src/main/res/layout-sw1080dp/fragment_meeting_date.xml
+++ b/android/app/src/main/res/layout-sw1080dp/fragment_meeting_date.xml
@@ -37,13 +37,13 @@
             android:id="@+id/dp_date"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/page_horizontal_margin"
             android:scaleX="2.0"
             android:scaleY="2.0"
-            android:layout_marginHorizontal="@dimen/page_horizontal_margin"
-            android:layout_marginTop="324dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_meet" />
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout-sw1080dp/fragment_meeting_time.xml
+++ b/android/app/src/main/res/layout-sw1080dp/fragment_meeting_time.xml
@@ -41,7 +41,7 @@
             style="@style/number_picker_style"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="96dp"
+            android:layout_marginTop="288dp"
             android:theme="@style/number_picker_style"
             android:value="@={vm.meetingHour}"
             android:scaleX="2.0"

--- a/android/app/src/main/res/layout-sw1080dp/fragment_meeting_time.xml
+++ b/android/app/src/main/res/layout-sw1080dp/fragment_meeting_time.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="vm"
+            type="com.mulberry.ody.presentation.creation.MeetingCreationViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_meeting_time_front"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="52dp"
+            android:text="@string/meeting_time_question_front"
+            android:textColor="@color/purple_800"
+            app:layout_constraintEnd_toStartOf="@id/tv_meeting_time_back"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_meeting_time_back"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/meeting_time_question_back"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/tv_meeting_time_front"
+            app:layout_constraintTop_toTopOf="@id/tv_meeting_time_front" />
+
+        <NumberPicker
+            android:id="@+id/np_meeting_time_hour"
+            style="@style/number_picker_style"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="96dp"
+            android:theme="@style/number_picker_style"
+            android:value="@={vm.meetingHour}"
+            android:scaleX="2.0"
+            android:scaleY="2.0"
+            app:layout_constraintEnd_toStartOf="@id/tv_meeting_time_separator"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_meeting_time_front"
+            app:timeValues="@{vm.Companion.MEETING_HOURS}" />
+
+        <TextView
+            android:id="@+id/tv_meeting_time_separator"
+            style="@style/pretendard_bold_28"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="128dp"
+            android:text="@string/meeting_time_separator"
+            android:scaleX="2.0"
+            android:scaleY="2.0"
+            app:layout_constraintBottom_toBottomOf="@id/np_meeting_time_hour"
+            app:layout_constraintEnd_toStartOf="@id/np_meeting_time_minute"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/np_meeting_time_hour"
+            app:layout_constraintTop_toTopOf="@id/np_meeting_time_hour" />
+
+        <NumberPicker
+            android:id="@+id/np_meeting_time_minute"
+            style="@style/number_picker_style"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:theme="@style/number_picker_style"
+            android:value="@={vm.meetingMinute}"
+            android:scaleX="2.0"
+            android:scaleY="2.0"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/tv_meeting_time_separator"
+            app:layout_constraintTop_toTopOf="@id/np_meeting_time_hour"
+            app:timeValues="@{vm.Companion.MEETING_MINUTES}" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout-sw1080dp/fragment_meeting_time.xml
+++ b/android/app/src/main/res/layout-sw1080dp/fragment_meeting_time.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
         <variable
             name="vm"
             type="com.mulberry.ody.presentation.creation.MeetingCreationViewModel" />
@@ -41,15 +42,15 @@
             style="@style/number_picker_style"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="288dp"
-            android:theme="@style/number_picker_style"
-            android:value="@={vm.meetingHour}"
             android:scaleX="2.0"
             android:scaleY="2.0"
+            android:theme="@style/number_picker_style"
+            android:value="@={vm.meetingHour}"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/tv_meeting_time_separator"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_meeting_time_front"
+            app:layout_constraintTop_toTopOf="parent"
             app:timeValues="@{vm.Companion.MEETING_HOURS}" />
 
         <TextView
@@ -58,9 +59,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="128dp"
-            android:text="@string/meeting_time_separator"
             android:scaleX="2.0"
             android:scaleY="2.0"
+            android:text="@string/meeting_time_separator"
             app:layout_constraintBottom_toBottomOf="@id/np_meeting_time_hour"
             app:layout_constraintEnd_toStartOf="@id/np_meeting_time_minute"
             app:layout_constraintHorizontal_chainStyle="packed"
@@ -72,10 +73,10 @@
             style="@style/number_picker_style"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:theme="@style/number_picker_style"
-            android:value="@={vm.meetingMinute}"
             android:scaleX="2.0"
             android:scaleY="2.0"
+            android:theme="@style/number_picker_style"
+            android:value="@={vm.meetingMinute}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/tv_meeting_time_separator"

--- a/android/app/src/main/res/layout-sw720dp/fragment_meeting_date.xml
+++ b/android/app/src/main/res/layout-sw720dp/fragment_meeting_date.xml
@@ -40,7 +40,7 @@
             android:scaleX="1.5"
             android:scaleY="1.5"
             android:layout_marginHorizontal="@dimen/page_horizontal_margin"
-            android:layout_marginTop="168dp"
+            android:layout_marginTop="128dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_meet" />

--- a/android/app/src/main/res/layout-sw720dp/fragment_meeting_date.xml
+++ b/android/app/src/main/res/layout-sw720dp/fragment_meeting_date.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.creation.date.MeetingDateFragment">
+
+        <TextView
+            android:id="@+id/tv_when"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="52dp"
+            android:text="@string/meeting_date_question_front"
+            android:textColor="@color/purple_800"
+            app:layout_constraintEnd_toStartOf="@+id/tv_meet"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_meet"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="@string/meeting_date_question_back"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_when"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/tv_when"
+            app:layout_constraintTop_toTopOf="@+id/tv_when" />
+
+        <DatePicker
+            android:id="@+id/dp_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:scaleX="1.5"
+            android:scaleY="1.5"
+            android:layout_marginHorizontal="@dimen/page_horizontal_margin"
+            android:layout_marginTop="168dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_meet" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout-sw720dp/fragment_meeting_date.xml
+++ b/android/app/src/main/res/layout-sw720dp/fragment_meeting_date.xml
@@ -40,10 +40,11 @@
             android:scaleX="1.5"
             android:scaleY="1.5"
             android:layout_marginHorizontal="@dimen/page_horizontal_margin"
-            android:layout_marginTop="128dp"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_meet" />
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout-sw720dp/fragment_meeting_time.xml
+++ b/android/app/src/main/res/layout-sw720dp/fragment_meeting_time.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
         <variable
             name="vm"
             type="com.mulberry.ody.presentation.creation.MeetingCreationViewModel" />
@@ -41,15 +42,16 @@
             style="@style/number_picker_style"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="100dp"
+            android:scaleX="1.5"
+
+            android:scaleY="1.5"
             android:theme="@style/number_picker_style"
             android:value="@={vm.meetingHour}"
-            android:scaleX="1.5"
-            android:scaleY="1.5"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/tv_meeting_time_separator"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_meeting_time_front"
+            app:layout_constraintTop_toTopOf="parent"
             app:timeValues="@{vm.Companion.MEETING_HOURS}" />
 
         <TextView
@@ -58,9 +60,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="48dp"
-            android:text="@string/meeting_time_separator"
             android:scaleX="1.5"
             android:scaleY="1.5"
+            android:text="@string/meeting_time_separator"
             app:layout_constraintBottom_toBottomOf="@id/np_meeting_time_hour"
             app:layout_constraintEnd_toStartOf="@id/np_meeting_time_minute"
             app:layout_constraintHorizontal_chainStyle="packed"
@@ -72,10 +74,10 @@
             style="@style/number_picker_style"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:theme="@style/number_picker_style"
-            android:value="@={vm.meetingMinute}"
             android:scaleX="1.5"
             android:scaleY="1.5"
+            android:theme="@style/number_picker_style"
+            android:value="@={vm.meetingMinute}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toEndOf="@id/tv_meeting_time_separator"

--- a/android/app/src/main/res/layout-sw720dp/fragment_meeting_time.xml
+++ b/android/app/src/main/res/layout-sw720dp/fragment_meeting_time.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="vm"
+            type="com.mulberry.ody.presentation.creation.MeetingCreationViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_meeting_time_front"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="52dp"
+            android:text="@string/meeting_time_question_front"
+            android:textColor="@color/purple_800"
+            app:layout_constraintEnd_toStartOf="@id/tv_meeting_time_back"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_meeting_time_back"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/meeting_time_question_back"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/tv_meeting_time_front"
+            app:layout_constraintTop_toTopOf="@id/tv_meeting_time_front" />
+
+        <NumberPicker
+            android:id="@+id/np_meeting_time_hour"
+            style="@style/number_picker_style"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="96dp"
+            android:theme="@style/number_picker_style"
+            android:value="@={vm.meetingHour}"
+            android:scaleX="1.5"
+            android:scaleY="1.5"
+            app:layout_constraintEnd_toStartOf="@id/tv_meeting_time_separator"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_meeting_time_front"
+            app:timeValues="@{vm.Companion.MEETING_HOURS}" />
+
+        <TextView
+            android:id="@+id/tv_meeting_time_separator"
+            style="@style/pretendard_bold_28"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="48dp"
+            android:text="@string/meeting_time_separator"
+            android:scaleX="1.5"
+            android:scaleY="1.5"
+            app:layout_constraintBottom_toBottomOf="@id/np_meeting_time_hour"
+            app:layout_constraintEnd_toStartOf="@id/np_meeting_time_minute"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/np_meeting_time_hour"
+            app:layout_constraintTop_toTopOf="@id/np_meeting_time_hour" />
+
+        <NumberPicker
+            android:id="@+id/np_meeting_time_minute"
+            style="@style/number_picker_style"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:theme="@style/number_picker_style"
+            android:value="@={vm.meetingMinute}"
+            android:scaleX="1.5"
+            android:scaleY="1.5"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/tv_meeting_time_separator"
+            app:layout_constraintTop_toTopOf="@id/np_meeting_time_hour"
+            app:timeValues="@{vm.Companion.MEETING_MINUTES}" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout-sw720dp/fragment_meeting_time.xml
+++ b/android/app/src/main/res/layout-sw720dp/fragment_meeting_time.xml
@@ -41,7 +41,7 @@
             style="@style/number_picker_style"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="96dp"
+            android:layout_marginTop="100dp"
             android:theme="@style/number_picker_style"
             android:value="@={vm.meetingHour}"
             android:scaleX="1.5"


### PR DESCRIPTION
# 🚩 연관 이슈 
close #704 


<br>

# 📝 작업 내용
- [x] 9인치, 12인치 화면에서 DatePicker 크기 수정
- [x] 9인치, 12인치 화면에서 TimePicker 크기 수정

<br>

# 🏞️ 스크린샷 (선택)


9인치 TimePicker, DatePicker
<img src="https://github.com/user-attachments/assets/90afe596-963c-445e-950f-8cacc7b1e8be"  width="30%" height="30%"/> <img src="https://github.com/user-attachments/assets/358948c7-9acd-4416-8c8a-ea228dd15d82"  width="30%" height="30%"/> <br>
12인치 TimePicker, DatePicker
<img src="https://github.com/user-attachments/assets/fedcb143-b082-4ac6-82cc-bfd91d0a14ca"  width="60%" height="60%"/> <img src="https://github.com/user-attachments/assets/536d662b-9d8d-4dbb-82e9-2c117e8c835c"  width="60%" height="60%"/> <br>

<br>

# 🗣️ 리뷰 요구사항 (선택)
이후에 글씨 크기를 조금 키우는 것이 좋을 것 같습니다.
실 기기로 느낌을 좀 볼 수 있으면 좋을텐데..