### PR TITLE
design: 로그인 화면 새로운 디자인으로 수정

### DIFF
--- a/android/app/src/main/res/layout-sw1080dp/activity_login.xml
+++ b/android/app/src/main/res/layout-sw1080dp/activity_login.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.mulberry.ody.presentation.login.LoginViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/cream"
+        android:gravity="center"
+        android:orientation="vertical"
+        tools:context=".presentation.login.LoginActivity">
+
+        <TextView
+            android:id="@+id/login_welcome_top"
+            style="@style/pretendard_bold_76"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="46dp"
+            android:layout_marginTop="240dp"
+            android:text="@string/login_welcome_top"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/login_welcome_prefix"
+            style="@style/pretendard_bold_76"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/login_welcome_prefix"
+            app:layout_constraintStart_toStartOf="@id/login_welcome_top"
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_top" />
+
+        <TextView
+            android:id="@+id/login_welcome_ody"
+            style="@style/pretendard_bold_76"
+            android:textColor="@color/purple_800"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/login_welcome_ody"
+            android:layout_marginStart="16dp"
+            app:layout_constraintStart_toEndOf="@id/login_welcome_prefix"
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"
+            app:layout_constraintTop_toTopOf="@id/login_welcome_prefix" />
+
+        <TextView
+            style="@style/pretendard_bold_76"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="@string/login_welcome_postfix"
+            app:layout_constraintStart_toEndOf="@id/login_welcome_ody"
+            app:layout_constraintTop_toTopOf="@id/login_welcome_prefix" />
+
+
+        <ImageView
+            android:layout_width="240dp"
+            android:layout_height="330dp"
+            android:layout_marginTop="84dp"
+            android:src="@drawable/ic_happy_ody"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"/>
+
+        <ImageView
+            android:layout_width="318dp"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="24dp"
+            android:onClick="@{() -> vm.loginWithKakao(context)}"
+            android:src="@drawable/img_kakao_login"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="477:72"
+            />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout-sw1080dp/activity_login.xml
+++ b/android/app/src/main/res/layout-sw1080dp/activity_login.xml
@@ -70,7 +70,7 @@
             app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"/>
 
         <ImageView
-            android:layout_width="318dp"
+            android:layout_width="477dp"
             android:layout_height="0dp"
             android:layout_marginHorizontal="20dp"
             android:layout_marginBottom="24dp"

--- a/android/app/src/main/res/layout-sw1080dp/activity_login.xml
+++ b/android/app/src/main/res/layout-sw1080dp/activity_login.xml
@@ -41,11 +41,11 @@
         <TextView
             android:id="@+id/login_welcome_ody"
             style="@style/pretendard_bold_76"
-            android:textColor="@color/purple_800"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/login_welcome_ody"
             android:layout_marginStart="16dp"
+            android:text="@string/login_welcome_ody"
+            android:textColor="@color/purple_800"
             app:layout_constraintStart_toEndOf="@id/login_welcome_prefix"
             app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"
             app:layout_constraintTop_toTopOf="@id/login_welcome_prefix" />
@@ -67,7 +67,7 @@
             android:src="@drawable/ic_happy_ody"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"/>
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix" />
 
         <ImageView
             android:layout_width="477dp"
@@ -76,11 +76,10 @@
             android:layout_marginBottom="24dp"
             android:onClick="@{() -> vm.loginWithKakao(context)}"
             android:src="@drawable/img_kakao_login"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintDimensionRatio="477:72"
-            />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout-sw720dp/activity_login.xml
+++ b/android/app/src/main/res/layout-sw720dp/activity_login.xml
@@ -41,11 +41,11 @@
         <TextView
             android:id="@+id/login_welcome_ody"
             style="@style/pretendard_bold_56"
-            android:textColor="@color/purple_800"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/login_welcome_ody"
             android:layout_marginStart="10dp"
+            android:text="@string/login_welcome_ody"
+            android:textColor="@color/purple_800"
             app:layout_constraintStart_toEndOf="@id/login_welcome_prefix"
             app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"
             app:layout_constraintTop_toTopOf="@id/login_welcome_prefix" />
@@ -67,7 +67,7 @@
             android:src="@drawable/ic_happy_ody"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"/>
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix" />
 
         <ImageView
             android:layout_width="318dp"
@@ -76,11 +76,10 @@
             android:layout_marginBottom="24dp"
             android:onClick="@{() -> vm.loginWithKakao(context)}"
             android:src="@drawable/img_kakao_login"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintDimensionRatio="477:72"
-            />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout-sw720dp/activity_login.xml
+++ b/android/app/src/main/res/layout-sw720dp/activity_login.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.mulberry.ody.presentation.login.LoginViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/cream"
+        android:gravity="center"
+        android:orientation="vertical"
+        tools:context=".presentation.login.LoginActivity">
+
+        <TextView
+            android:id="@+id/login_welcome_top"
+            style="@style/pretendard_bold_56"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="46dp"
+            android:layout_marginTop="240dp"
+            android:text="@string/login_welcome_top"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/login_welcome_prefix"
+            style="@style/pretendard_bold_56"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/login_welcome_prefix"
+            app:layout_constraintStart_toStartOf="@id/login_welcome_top"
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_top" />
+
+        <TextView
+            android:id="@+id/login_welcome_ody"
+            style="@style/pretendard_bold_56"
+            android:textColor="@color/purple_800"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/login_welcome_ody"
+            android:layout_marginStart="10dp"
+            app:layout_constraintStart_toEndOf="@id/login_welcome_prefix"
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"
+            app:layout_constraintTop_toTopOf="@id/login_welcome_prefix" />
+
+        <TextView
+            style="@style/pretendard_bold_56"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@string/login_welcome_postfix"
+            app:layout_constraintStart_toEndOf="@id/login_welcome_ody"
+            app:layout_constraintTop_toTopOf="@id/login_welcome_prefix" />
+
+
+        <ImageView
+            android:layout_width="160dp"
+            android:layout_height="220dp"
+            android:layout_marginTop="56dp"
+            android:src="@drawable/ic_happy_ody"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"/>
+
+        <ImageView
+            android:layout_width="318dp"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="24dp"
+            android:onClick="@{() -> vm.loginWithKakao(context)}"
+            android:src="@drawable/img_kakao_login"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="477:72"
+            />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/activity_login.xml
+++ b/android/app/src/main/res/layout/activity_login.xml
@@ -13,19 +13,61 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/purple_800"
+        android:background="@color/cream"
         android:gravity="center"
         android:orientation="vertical"
         tools:context=".presentation.login.LoginActivity">
 
-        <ImageView
+        <TextView
+            android:id="@+id/login_welcome_top"
+            style="@style/pretendard_bold_24"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/img_ody_logo"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginStart="46dp"
+            android:layout_marginTop="173dp"
+            android:text="@string/login_welcome_top"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/login_welcome_prefix"
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/login_welcome_prefix"
+            app:layout_constraintStart_toStartOf="@id/login_welcome_top"
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_top" />
+
+        <TextView
+            android:id="@+id/login_welcome_ody"
+            style="@style/pretendard_bold_24"
+            android:textColor="@color/purple_800"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/login_welcome_ody"
+            android:layout_marginStart="4dp"
+            app:layout_constraintStart_toEndOf="@id/login_welcome_prefix"
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"
+            app:layout_constraintTop_toTopOf="@id/login_welcome_prefix" />
+
+        <TextView
+            style="@style/pretendard_bold_24"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="@string/login_welcome_postfix"
+            app:layout_constraintStart_toEndOf="@id/login_welcome_ody"
+            app:layout_constraintTop_toTopOf="@id/login_welcome_prefix" />
+
+
+        <ImageView
+            android:layout_width="80dp"
+            android:layout_height="110dp"
+            android:layout_marginTop="39dp"
+            android:src="@drawable/ic_happy_ody"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"/>
 
         <ImageView
             android:layout_width="0dp"

--- a/android/app/src/main/res/layout/activity_login.xml
+++ b/android/app/src/main/res/layout/activity_login.xml
@@ -41,11 +41,11 @@
         <TextView
             android:id="@+id/login_welcome_ody"
             style="@style/pretendard_bold_24"
-            android:textColor="@color/purple_800"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/login_welcome_ody"
             android:layout_marginStart="4dp"
+            android:text="@string/login_welcome_ody"
+            android:textColor="@color/purple_800"
             app:layout_constraintStart_toEndOf="@id/login_welcome_prefix"
             app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"
             app:layout_constraintTop_toTopOf="@id/login_welcome_prefix" />
@@ -67,7 +67,7 @@
             android:src="@drawable/ic_happy_ody"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix"/>
+            app:layout_constraintTop_toBottomOf="@id/login_welcome_prefix" />
 
         <ImageView
             android:layout_width="0dp"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -88,6 +88,10 @@
     <string name="invite_code_already_participated">이미 참여한 약속입니다.</string>
 
     <!-- activity_login -->
+    <string name="login_welcome_top">카카오톡으로</string>
+    <string name="login_welcome_prefix">간단하게</string>
+    <string name="login_welcome_ody">오디</string>
+    <string name="login_welcome_postfix">시작하기</string>
     <string name="login_logout_success">로그아웃 되었습니다.</string>
     <string name="login_withdrawal_success">회원 탈퇴 되었습니다.</string>
 

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <style name="pretendard_bold_56">
+        <item name="android:textSize">56dp</item>
+        <item name="android:textColor">@color/gray_800</item>
+        <item name="android:fontFamily">@font/pretendard_bold</item>
+    </style>
+
     <style name="pretendard_bold_28">
         <item name="android:textSize">28dp</item>
         <item name="android:textColor">@color/gray_800</item>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <style name="pretendard_bold_76">
+        <item name="android:textSize">76dp</item>
+        <item name="android:textColor">@color/gray_800</item>
+        <item name="android:fontFamily">@font/pretendard_bold</item>
+    </style>
+
     <style name="pretendard_bold_56">
         <item name="android:textSize">56dp</item>
         <item name="android:textColor">@color/gray_800</item>


### PR DESCRIPTION
# 🚩 연관 이슈

close #706

<br>

# 📝 작업 내용

- [x]  로그인 화면 새로운 디자인으로 수정
- [x]  9인치 로그인 화면 추가
- [x]  12인치 로그인 화면 추가

<br>

# 🏞️ 스크린샷 (선택)

차례대로 일반 폰, 9인치 태블릿, 12인치 태블릿입니다.
<img src="https://github.com/user-attachments/assets/ac0765ef-5872-42ae-bb8e-6b19429a5e29"  width="30%" height="30%"/> <br>
<img src="https://github.com/user-attachments/assets/d2a06937-3cf7-4ac6-900c-f99bec2c6b8d"  width="60%" height="60%"/> <br>
<img src="https://github.com/user-attachments/assets/55706e59-3068-4324-a524-1d6d1b5b864a"  width="90%" height="90%"/> <br>


<br>

# 🗣️ 리뷰 요구사항 (선택)

브랜치 지우고 다시 만들어 PR 올립니다
이젠 되겠죠?