### PR TITLE
hotfix: 스케줄링 정확한 알림 권한 수정

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-configuration android:name="android:permission.POST_NOTIFICATIONS" />
 
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />


### PR DESCRIPTION
# 🚩 연관 이슈 
close #722


<br>

# 📝 작업 내용


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
정확한 알림을 받기 위한 permission 종류가 두가지가 있는데요.
`SCHEDULE_EXACT_ALARM`랑 `USE_EXACT_ALARM`입니다.

저는 `SCHEDULE_EXACT_ALARM`를 사용하고 있었는데, 이 경우 사용자에게 명시적으로 권한을 받아야 한다고 하더라구요.
그런데 권한을 받는 코드가 없어서 생기는 오류였어요.. (왜 내 폰은 잘 되지..)

`USE_EXACT_ALARM`는 명시적으로 권한을 받지 않아도 되어서 편리하지만, 그만큼 더 구글의 제약사항들이 많은 것 같아요.
그래서 `USE_EXACT_ALARM`는 앱의 핵심기능이 정확한 알람인 경우에만 사용하라고 권장하고 있는데, 저희는 핵심기능이 정확한 알람이니 일단 `USE_EXACT_ALARM`로 변경해보겠습니다..!! 

PR merge되면 바로 앱 업데이트 올릴게요

참고 공식 문서: https://developer.android.com/develop/background-work/services/alarms/schedule?hl=ko#exact-permission-declare