### PR TITLE
design: 주소 검색 item 디자인 수정

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
@@ -3,14 +3,18 @@ package com.mulberry.ody.presentation.address
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.View
+import android.widget.LinearLayout
 import androidx.activity.OnBackPressedCallback
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
+import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.mulberry.ody.R
 import com.mulberry.ody.databinding.FragmentAddressSearchBinding
 import com.mulberry.ody.presentation.address.adapter.AddressesAdapter
 import com.mulberry.ody.presentation.address.listener.AddressSearchListener
 import com.mulberry.ody.presentation.common.binding.BindingFragment
 import com.mulberry.ody.presentation.common.listener.BackListener
+import com.mulberry.ody.presentation.common.toPixel
 import com.mulberry.ody.presentation.launchWhenStarted
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -46,6 +50,15 @@ class AddressSearchFragment :
     }
 
     private fun initializeAddressAdapter() {
+        val horizontalMarginPixel = ADDRESS_ITEM_HORIZONTAL_MARGIN_DP.toPixel(requireContext())
+        val dividerItemDecoration =
+            MaterialDividerItemDecoration(requireContext(), LinearLayout.VERTICAL).apply {
+                isLastItemDecorated = false
+                dividerColor = ContextCompat.getColor(requireContext(), R.color.gray_350)
+                dividerInsetStart = horizontalMarginPixel
+                dividerInsetEnd = horizontalMarginPixel
+            }
+        binding.rvAddress.addItemDecoration(dividerItemDecoration)
         binding.rvAddress.adapter = adapter
     }
 
@@ -97,5 +110,9 @@ class AddressSearchFragment :
 
     override fun onBack() {
         parentFragmentManager.popBackStack()
+    }
+
+    companion object {
+        private const val ADDRESS_ITEM_HORIZONTAL_MARGIN_DP = 26
     }
 }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/common/DimensionExtensions.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/common/DimensionExtensions.kt
@@ -1,0 +1,8 @@
+package com.mulberry.ody.presentation.common
+
+import android.content.Context
+
+fun Int.toPixel(context: Context): Int {
+    val density = context.resources.displayMetrics.density
+    return (this * density).toInt()
+}

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingActivity.kt
@@ -6,12 +6,14 @@ import android.net.Uri
 import android.os.Bundle
 import android.widget.LinearLayout
 import androidx.activity.viewModels
+import androidx.core.content.ContextCompat
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.mulberry.ody.BuildConfig
 import com.mulberry.ody.R
 import com.mulberry.ody.databinding.ActivitySettingBinding
 import com.mulberry.ody.presentation.common.binding.BindingActivity
 import com.mulberry.ody.presentation.common.listener.BackListener
+import com.mulberry.ody.presentation.common.toPixel
 import com.mulberry.ody.presentation.launchWhenStarted
 import com.mulberry.ody.presentation.login.LoginActivity
 import com.mulberry.ody.presentation.login.LoginNavigatedReason
@@ -79,11 +81,13 @@ class SettingActivity :
     }
 
     private fun initializeSettingAdapter() {
+        val horizontalMarginPixel = SETTING_ITEM_HORIZONTAL_MARGIN_DP.toPixel(this)
         val dividerItemDecoration =
             MaterialDividerItemDecoration(this, LinearLayout.VERTICAL).apply {
                 isLastItemDecorated = false
-                dividerInsetStart = dpToPx(SETTING_ITEM_HORIZONTAL_MARGIN_DP)
-                dividerInsetEnd = dpToPx(SETTING_ITEM_HORIZONTAL_MARGIN_DP)
+                dividerColor = ContextCompat.getColor(this@SettingActivity, R.color.gray_350)
+                dividerInsetStart = horizontalMarginPixel
+                dividerInsetEnd = horizontalMarginPixel
             }
         binding.rvSetting.addItemDecoration(dividerItemDecoration)
         adapter.submitList(SettingUiModel.entries)
@@ -129,11 +133,6 @@ class SettingActivity :
             }
         startActivity(intent)
         finishAffinity()
-    }
-
-    private fun dpToPx(dp: Int): Int {
-        val density = resources.displayMetrics.density
-        return (dp * density).toInt()
     }
 
     companion object {


### PR DESCRIPTION
# 🚩 연관 이슈 
close #742


<br>

# 📝 작업 내용
- [x] 주소 검색 item divider 추가
- [x] 주소 검색 item divider 컬러 변경
- [x] dp 를 pixel로 변경하는 확장 함수 구현

<br>

# 🏞️ 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/d43c7584-003a-4069-b9b3-dc78a4026470" width="400">


<br>

# 🗣️ 리뷰 요구사항 (선택)
divider 컬러가 피그마랑 조금 다르길래 명시적으로 지정해주었습니다!
dp to px 함수가 이미 구현되어있길래, common 확장함수로 분리했어요