### PR TITLE
fix: 로그인 후 뒤로가기를 하면 앱이 종료되지 않고 로그인 화면으로 돌아가는 문제 수정

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginActivity.kt
@@ -46,6 +46,7 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
                 viewModel.navigateAction.collect {
                     val intent = MeetingsActivity.getIntent(this@LoginActivity)
                     startActivity(intent)
+                    finish()
                 }
             }
             launch {


### PR DESCRIPTION
# 🚩 연관 이슈 
close #745 


<br>

# 📝 작업 내용
- [x] LoginActivity에서 startActivity 호출 후 finish() 호출

<br>

# 🏞️ 스크린샷 (선택)

https://github.com/user-attachments/assets/44525fb4-288d-400a-a3ed-746d97fa055b



<br>

# 🗣️ 리뷰 요구사항 (선택)
