### PR TITLE
fix: Foreground Service 여러 작업 수행 가능하도록 수정

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardCloseBroadcastReceiver.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardCloseBroadcastReceiver.kt
@@ -15,6 +15,6 @@ class EtaDashboardCloseBroadcastReceiver : BroadcastReceiver() {
         if (meetingId == MEETING_ID_DEFAULT_VALUE) return
 
         val serviceIntent = EtaDashboardService.getIntent(context, meetingId, isOpen = false)
-        context.stopService(serviceIntent)
+        context.startForegroundService(serviceIntent)
     }
 }

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
@@ -59,6 +59,9 @@ class EtaDashboardService : Service() {
 
             CLOSE_ACTION -> {
                 closeEtaDashboard(meetingId)
+                if (meetingJobs.isEmpty()) {
+                    stopSelf()
+                }
             }
         }
         return START_REDELIVER_INTENT
@@ -111,8 +114,8 @@ class EtaDashboardService : Service() {
     }
 
     private fun closeEtaDashboard(meetingId: Long) {
-        val job = meetingJobs.remove(meetingId) ?: return
-        job.cancel()
+        val job = meetingJobs.remove(meetingId)
+        job?.cancel()
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
# 🚩 연관 이슈 
close #747 

<br>

# 📝 작업 내용
- [x] 동시에 여러 약속에 대한 작업을 수행하는 경우 하나의 작업 소멸 시 모든 작업이 소멸되는 버그 해결

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
`Service` 객체가 싱글톤 인스턴스이기 때문에, `stopService()`를 호출하면 서비스 객체가 소멸되어 모든 폴링 작업이 끝나는 현상이 있었습니다. 즉, 동시에 여러 약속에 대한 폴링 작업을 수행 중인 경우 하나의 폴링 작업이 끝나면 모든 폴링 작업이 끝난다는 버그가 존재했습니다.

이를 아래 방식으로 해결했습니다~
1. 폴링 작업을 끝내야 할 때 `stopService()`를 호출하지 않고, `startForegroundService()`를 호출
2. Serivce 내부에서 폴링 작업이 0개인 경우에만 `stopSelf()`를 통해 서비스 인스턴스를 소멸시키도록 수정