### PR TITLE
fix: 원(인디케이터)을 통해 강제 이동 가능 막기

### DIFF
--- a/android/app/src/main/res/layout/activity_meeting_creation.xml
+++ b/android/app/src/main/res/layout/activity_meeting_creation.xml
@@ -32,6 +32,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="50dp"
+            app:dotsClickable="false"
             app:dotsColor="@color/gray_350"
             app:dotsCornerRadius="50dp"
             app:dotsSize="10dp"


### PR DESCRIPTION
# 🚩 연관 이슈 
close #754 


<br>

# 📝 작업 내용
- [x] 원(인디케이터)을 통해 강제 이동 가능 막기

<br>

# 🏞️ 스크린샷 (선택)

https://github.com/user-attachments/assets/5c39ae75-d1ca-422f-8021-4438f0d1c520

가끔 보이는 조그만한 하얀 원같은게 터치 지점입니다

<br>

# 🗣️ 리뷰 요구사항 (선택)
