### PR TITLE
design: 약속 이름이 길 때 말줄임표 대신 약속 이름을 모두 보여줄 수 있도록 수정

### DIFF
--- a/android/app/src/main/res/layout/activity_meeting_creation.xml
+++ b/android/app/src/main/res/layout/activity_meeting_creation.xml
@@ -32,6 +32,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="50dp"
+            app:dotsClickable="false"
             app:dotsColor="@color/gray_350"
             app:dotsCornerRadius="50dp"
             app:dotsSize="10dp"

--- a/android/app/src/main/res/layout/item_meeting_catalog.xml
+++ b/android/app/src/main/res/layout/item_meeting_catalog.xml
@@ -38,7 +38,7 @@
             android:layout_marginTop="22dp"
             android:layout_marginBottom="4dp"
             android:ellipsize="end"
-            android:maxLines="1"
+            android:maxLines="2"
             android:text="@{meeting.name}"
             app:layout_constraintEnd_toStartOf="@id/iv_arrow"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/app/src/main/res/layout/toolbar_notification_log.xml
+++ b/android/app/src/main/res/layout/toolbar_notification_log.xml
@@ -41,20 +41,29 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
-                android:id="@+id/tv_title"
-                style="@style/pretendard_bold_24"
+            <HorizontalScrollView
+                android:id="@+id/hsv_title"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="14dp"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:text="@{title}"
+                android:fadingEdgeLength="30dp"
+                android:overScrollMode="never"
+                android:requiresFadingEdge="horizontal"
+                android:scrollbars="none"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/tv_mate_count"
                 app:layout_constraintStart_toEndOf="@id/iv_back"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="아주긴모임이름아주긴모임이름" />
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:id="@+id/tv_title"
+                    style="@style/pretendard_bold_24"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:text="@{title}"
+                    tools:text="아주긴모임이름아주긴모임이름아주긴모임이름아" />
+            </HorizontalScrollView>
 
             <TextView
                 android:id="@+id/tv_mate_count"
@@ -65,7 +74,7 @@
                 android:textColor="@color/gray_500"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/iv_menu"
-                app:layout_constraintStart_toEndOf="@id/tv_title"
+                app:layout_constraintStart_toEndOf="@id/hsv_title"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="3명" />
 


### PR DESCRIPTION
# 🚩 연관 이슈 
close #759


<br>

# 📝 작업 내용
- [x] 약속 목록 화면에서 약속 이름이 뷰보다 길 때 2줄로 보여주기
- [x] 로그 화면 및 eta 화면에서 약속 이름을 스와이프해서 볼 수 있도록 변경


<br>

# 🏞️ 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/23ae13e8-d6ed-46ae-ac1a-8302963294c1"  width="60%" height="60%"/>
<br>

https://github.com/user-attachments/assets/e4810da2-c28d-4a87-b402-af0a4ad57a88


# 🗣️ 리뷰 요구사항 (선택)
