### PR TITLE
fix: 다크모드 초대코드 복사 창에서 왼쪽 위 흰색 제거

### DIFF
--- a/android/app/src/main/res/layout/fragment_notification_log.xml
+++ b/android/app/src/main/res/layout/fragment_notification_log.xml
@@ -158,6 +158,7 @@
 
         <com.google.android.material.navigation.NavigationView
             android:id="@+id/nv_notification_log"
+            android:background="@color/septenary"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_gravity="end">


### PR DESCRIPTION
# 🚩 연관 이슈 
close #786 


<br>

# 📝 작업 내용
- [x] 다크모드 초대코드 복사 창에서 왼쪽 위 흰색 제거

<br>

# 🏞️ 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/af46e8c0-2873-4ce7-9241-befdd8bfb94a"  width="30%" height="60%"/>

<br>

# 🗣️ 리뷰 요구사항 (선택)
