### PR TITLE
refactor: 약속 시간 이후 30분까지 nudge가 가능하도록 수정

### DIFF
--- a/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
+++ b/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
@@ -145,7 +145,7 @@ class MateServiceTest extends BaseServiceTest {
                     .isInstanceOf(OdyBadRequestException.class);
         }
 
-        @DisplayName("약속 30분 이후 이전까지 mate를 재촉할 수 있다")
+        @DisplayName("약속 30분 이후까지 mate를 재촉할 수 있다")
         @Test
         void nudgeSuccessWhenTimeWithInNudgeAvailableTime() {
             Meeting availableNudgeMeeting = fixtureGenerator.generateMeeting(LocalDateTime.now().minusMinutes(30L));

--- a/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
+++ b/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
@@ -145,7 +145,7 @@ class MateServiceTest extends BaseServiceTest {
                     .isInstanceOf(OdyBadRequestException.class);
         }
 
-        @DisplayName("약속 이후 30분 까지 mate를 재촉할 수 있다")
+        @DisplayName("약속 30분 이후 이전까지 mate를 재촉할 수 있다")
         @Test
         void nudgeSuccessWhenTimeWithInNudgeAvailableTime() {
             Meeting availableNudgeMeeting = fixtureGenerator.generateMeeting(LocalDateTime.now().minusMinutes(30L));
@@ -159,7 +159,7 @@ class MateServiceTest extends BaseServiceTest {
             Mockito.verify(fcmPushSender, times(1)).sendNudgeMessage(any(Notification.class), any(DirectMessage.class));
         }
 
-        @DisplayName("약속 이후 30분 이후에는 mate를 재촉할 수 없다")
+        @DisplayName("약속 30분 이후에는 mate를 재촉할 수 없다")
         @Test
         void nudgeFailWhenTimeIsNotWithInNudgeAvailableTime() {
             Meeting notAvailableNudgeMeeting = fixtureGenerator.generateMeeting(LocalDateTime.now().minusMinutes(31L));


### PR DESCRIPTION
# 🚩 연관 이슈 
close #795 


<br>

# 📝 작업 내용
- [x] #795 

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)

- nudge에 대한 검증조건을 추가하면서 느낀 건데 nudge에 대한 조건이 조금 커지면서 이제 분리할 시기가 온 것 같아요. 현재는 모든 nudge 관련 도메인이 mateService 내에 녹아있는데 어떻게 분리하면 좋을지 의견 받습니다. 저는 개인적으로 etaService 안으로 넣어주거나, nudgeService를 새로 만드는 것도 방법이라 생각합니다. 다만 이 경우 mateSevice가 nudgeService를 가지게 되므로 의존성이 과해진다는 문제가 생길 수도 있을 것 같아요.