### PR TITLE
fix: 다크모드일 때 스플래시 로고 이상하게 보이는 문제 수정

### DIFF
--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -9,7 +9,7 @@
     <style name="Theme.Ody" parent="Base.Theme.Ody" />
 
     <style name="AppTheme.Splash" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/secondary</item>
+        <item name="windowSplashScreenBackground">@color/purple_800</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_screen</item>
         <item name="postSplashScreenTheme">@style/Theme.Ody</item>
     </style>


### PR DESCRIPTION
# 🚩 연관 이슈 
close #805 


<br>

# 📝 작업 내용
- [x] 다크모드일 때 스플래시 로고 배경 색상 변경

<br>

# 🏞️ 스크린샷 (선택)
- Before
<img src="https://github.com/user-attachments/assets/22c67ff1-07b5-49cc-9376-c79da6f4babb"  width="30%" height="30%"/>
<br>
- After <br>
<img src="https://github.com/user-attachments/assets/1ebc55e3-2ce0-4a3b-a76b-6d105fc122a8"  width="30%" height="30%"/>

<br>

# 🗣️ 리뷰 요구사항 (선택)
