### PR TITLE
fix: Room Entity 마이그레이션 버그 수정

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/data/local/db/OdyDatabase.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/db/OdyDatabase.kt
@@ -40,7 +40,7 @@ abstract class OdyDatabase : RoomDatabase() {
                              `isOpen` INTEGER NOT NULL
                         )
                         """.trimIndent(),
-                        )
+                    )
                     db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS `eta_info_temp` (

--- a/android/app/src/main/java/com/mulberry/ody/data/local/db/OdyDatabase.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/db/OdyDatabase.kt
@@ -9,7 +9,12 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.mulberry.ody.data.local.entity.eta.MateEtaInfoEntity
 import com.mulberry.ody.data.local.entity.eta.MateEtaListTypeConverter
+import com.mulberry.ody.data.local.entity.eta.OldMateEtaListTypeConverter
 import com.mulberry.ody.data.local.entity.reserve.EtaReservationEntity
+import com.mulberry.ody.domain.model.EtaStatus
+import com.mulberry.ody.domain.model.EtaType2
+import com.mulberry.ody.domain.model.MateEta
+import com.mulberry.ody.domain.model.MateEta2
 
 @Database(
     entities = [MateEtaInfoEntity::class, EtaReservationEntity::class],
@@ -31,11 +36,57 @@ abstract class OdyDatabase : RoomDatabase() {
                         CREATE TABLE IF NOT EXISTS `eta_reservation` (
                             `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                             `meetingId` INTEGER NOT NULL,
-                            `reserveMillis` INTEGER NOT NULL,
-                            `isOpen` INTEGER NOT NULL
+                             `reserveMillis` INTEGER NOT NULL,
+                             `isOpen` INTEGER NOT NULL
+                        )
+                        """.trimIndent(),
+                        )
+                    db.execSQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS `eta_info_temp` (
+                            `meetingId` INTEGER PRIMARY KEY NOT NULL, 
+                            `mateId` INTEGER NOT NULL, 
+                            `mateEtas` TEXT NOT NULL
                         )
                         """.trimIndent(),
                     )
+
+                    val cursor = db.query("SELECT * FROM eta_info")
+                    if (cursor.moveToFirst()) {
+                        do {
+                            val meetingId = cursor.getLong(cursor.getColumnIndexOrThrow("meetingId"))
+                            val mateId = cursor.getLong(cursor.getColumnIndexOrThrow("mateId"))
+                            val mateEtasJson = cursor.getString(cursor.getColumnIndexOrThrow("mateEtas"))
+
+                            val oldMateEtas: List<MateEta2> = OldMateEtaListTypeConverter().fromString(mateEtasJson) ?: emptyList()
+                            val newMateEtas =
+                                oldMateEtas.map { oldMateEta ->
+                                    MateEta(
+                                        mateId = oldMateEta.mateId,
+                                        nickname = oldMateEta.nickname,
+                                        etaStatus =
+                                            when (oldMateEta.etaType) {
+                                                EtaType2.ARRIVED -> EtaStatus.Arrived
+                                                EtaType2.ARRIVAL_SOON -> EtaStatus.ArrivalSoon(oldMateEta.durationMinute)
+                                                EtaType2.LATE_WARNING -> EtaStatus.LateWarning(oldMateEta.durationMinute)
+                                                EtaType2.LATE -> EtaStatus.Late(oldMateEta.durationMinute)
+                                                EtaType2.MISSING -> EtaStatus.Missing
+                                            },
+                                    )
+                                }
+
+                            val newMateEtasJson = MateEtaListTypeConverter().fromMateEta(newMateEtas)
+
+                            db.execSQL(
+                                "INSERT INTO eta_info_temp (meetingId, mateId, mateEtas) VALUES (?, ?, ?)",
+                                arrayOf(meetingId, mateId, newMateEtasJson),
+                            )
+                        } while (cursor.moveToNext())
+                    }
+
+                    cursor.close()
+                    db.execSQL("DROP TABLE eta_info")
+                    db.execSQL("ALTER TABLE eta_info_temp RENAME TO eta_info")
                 }
             }
 

--- a/android/app/src/main/java/com/mulberry/ody/data/local/entity/eta/MateEtaListTypeConverter.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/entity/eta/MateEtaListTypeConverter.kt
@@ -1,6 +1,5 @@
 package com.mulberry.ody.data.local.entity.eta
 
-import android.util.Log
 import androidx.room.ProvidedTypeConverter
 import androidx.room.TypeConverter
 import com.mulberry.ody.domain.model.EtaStatus
@@ -28,9 +27,7 @@ class MateEtaListTypeConverter {
                 is EtaStatus.Missing -> """{"type":"Missing"}"""
             }
 
-        return """{"mateId":${mateEta.mateId},"nickname":"${mateEta.nickname}","etaStatus":$etaStatusString}""".also {
-            Log.e("TEST", "$it")
-        }
+        return """{"mateId":${mateEta.mateId},"nickname":"${mateEta.nickname}","etaStatus":$etaStatusString}"""
     }
 
     private fun fromJson(json: String): MateEta {
@@ -41,7 +38,7 @@ class MateEtaListTypeConverter {
                     val (key, value) =
                         it.split(":", limit = 2)
                             .map { it.trim().removeSurrounding("\"") }
-                    (key to value).also { Log.e("TEST", "${it.first} ${it.second}")}
+                    (key to value)
                 }
 
         val mateId = jsonObject["mateId"]!!.toLong()

--- a/android/app/src/main/java/com/mulberry/ody/data/local/entity/eta/MateEtaListTypeConverter.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/entity/eta/MateEtaListTypeConverter.kt
@@ -1,5 +1,6 @@
 package com.mulberry.ody.data.local.entity.eta
 
+import android.util.Log
 import androidx.room.ProvidedTypeConverter
 import androidx.room.TypeConverter
 import com.mulberry.ody.domain.model.EtaStatus
@@ -8,7 +9,7 @@ import com.mulberry.ody.domain.model.MateEta
 @ProvidedTypeConverter
 class MateEtaListTypeConverter {
     @TypeConverter
-    fun fromString(value: String): List<MateEta>? {
+    fun fromString(value: String): List<MateEta> {
         return value.split(";").map { fromJson(it) }
     }
 
@@ -17,7 +18,7 @@ class MateEtaListTypeConverter {
         return type.joinToString(";") { toJson(it) }
     }
 
-    private fun toJson(mateEta: MateEta): String {
+    fun toJson(mateEta: MateEta): String {
         val etaStatusString =
             when (mateEta.etaStatus) {
                 is EtaStatus.Arrived -> """{type:"Arrived"}"""
@@ -27,7 +28,9 @@ class MateEtaListTypeConverter {
                 is EtaStatus.Missing -> """{"type":"Missing"}"""
             }
 
-        return """{"mateId":${mateEta.mateId},"nickname":"${mateEta.nickname}","etaStatus":$etaStatusString}"""
+        return """{"mateId":${mateEta.mateId},"nickname":"${mateEta.nickname}","etaStatus":$etaStatusString}""".also {
+            Log.e("TEST", "$it")
+        }
     }
 
     private fun fromJson(json: String): MateEta {
@@ -38,7 +41,7 @@ class MateEtaListTypeConverter {
                     val (key, value) =
                         it.split(":", limit = 2)
                             .map { it.trim().removeSurrounding("\"") }
-                    key to value
+                    (key to value).also { Log.e("TEST", "${it.first} ${it.second}")}
                 }
 
         val mateId = jsonObject["mateId"]!!.toLong()

--- a/android/app/src/main/java/com/mulberry/ody/data/local/entity/eta/OldMateEtaListTypeConverter.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/entity/eta/OldMateEtaListTypeConverter.kt
@@ -1,0 +1,28 @@
+package com.mulberry.ody.data.local.entity.eta
+
+import androidx.room.ProvidedTypeConverter
+import androidx.room.TypeConverter
+import com.mulberry.ody.domain.model.MateEta2
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+
+@ProvidedTypeConverter
+class OldMateEtaListTypeConverter(
+    private val moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build(),
+) {
+    @TypeConverter
+    fun fromString(value: String): List<MateEta2>? {
+        val listType = Types.newParameterizedType(List::class.java, MateEta2::class.java)
+        val adapter: JsonAdapter<List<MateEta2>> = moshi.adapter(listType)
+        return adapter.fromJson(value)
+    }
+
+    @TypeConverter
+    fun fromMateEta(type: List<MateEta2>): String {
+        val listType = Types.newParameterizedType(List::class.java, MateEta2::class.java)
+        val adapter: JsonAdapter<List<MateEta2>> = moshi.adapter(listType)
+        return adapter.toJson(type)
+    }
+}

--- a/android/app/src/main/java/com/mulberry/ody/domain/model/EtaType2.kt
+++ b/android/app/src/main/java/com/mulberry/ody/domain/model/EtaType2.kt
@@ -1,0 +1,9 @@
+package com.mulberry.ody.domain.model
+
+enum class EtaType2 {
+    LATE_WARNING,
+    ARRIVAL_SOON,
+    ARRIVED,
+    LATE,
+    MISSING,
+}

--- a/android/app/src/main/java/com/mulberry/ody/domain/model/MateEta2.kt
+++ b/android/app/src/main/java/com/mulberry/ody/domain/model/MateEta2.kt
@@ -1,0 +1,8 @@
+package com.mulberry.ody.domain.model
+
+data class MateEta2(
+    val mateId: Long,
+    val nickname: String,
+    val etaType: EtaType2,
+    val durationMinute: Int,
+)


### PR DESCRIPTION
# 🚩 연관 이슈 
close #831


<br>

# 📝 작업 내용


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
Room에 저장된 EtaType이 사라지고 EtaStatus로 대체되었는데요.
이 과정에서 기존 EtaType으로 저장된 Entity들이 제대로 변환되지 않아 계속 앱이 터졌었어요.
EtaType -> EtaStatus 마이그레이션 코드 작성했습니다! 
그런데 코드가 너무 더러워요................ 일단.... 이대로 머지하고 앱 업데이트 이후 리팩터링해도 될까요?
EtaStatus 리팩터링 쉬운 줄 알았는데 고려할게 많네요 흑흑흑흑흑흑흑흑