### PR TITLE
fix: cd 스크립트 local.properties 제대로 들어가지 않는 문제 수정

### DIFF
--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -43,11 +43,20 @@ jobs:
         run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ./app/google-services.json
 
       - name: Add local.properties
+        env:
+          BASE_DEV_URL: ${{secrets.BASE_DEV_URL}}
+          BASE_PROD_URL: ${{secrets.BASE_PROD_URL}}
+          KAKAO_API_KEY: ${{secrets.KAKAO_API_KEY}}
+          KAKAO_NATIVE_KEY: ${{secrets.KAKAO_NATIVE_KEY}}
+          TERM_URI: ${{secrets.TERM_URI}}
+          PRIVACY_POLICY_URL: ${{secrets.PRIVACY_POLICY_URI}}
         run: |
-          echo base_dev_url='${{ secrets.BASE_DEV_URL }}' > ./local.properties
-          echo base_prod_url='${{ secrets.BASE_PROD_URL }}' > ./local.properties
-          echo kakao_api_key='{{ secrets.KAKAO_API_KEY }}' > ./local.properties
-          echo kakao_native_key='{{ secrets.KAKAO_NATIVE_KEY }}' > ./local.properties
+          echo "BASE_DEV_URL=\"$BASE_DEV_URL\"" >> ./local.properties
+          echo "BASE_PROD_URL=\"$BASE_PROD_URL\"" >> ./local.properties
+          echo "KAKAO_API_KEY=\"$KAKAO_API_KEY\"" >> ./local.properties
+          echo "KAKAO_NATIVE_KEY=\"$KAKAO_NATIVE_KEY\"" >> ./local.properties
+          echo "TERM_URI=\"$TERM_URI\"" >> ./local.properties
+          echo "PRIVACY_POLICY_URL=\"$PRIVACY_POLICY_URI\"" >> ./local.properties
 
       - name: Change gradlew permissions
         run: chmod +x ./gradlew


### PR DESCRIPTION
# 🚩 연관 이슈 
close #847


<br>

# 📝 작업 내용
- [x] secrets 환경 변수로 분리
- [x] > 연산자에서 >> 연산자로 변경
- [x] local.properties에 들어갈 변수 이름 소문자에서 대문자로 변경

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
공개테스트 1001 버전으로 테스트했고, 로그인 잘 되는 것 같습니다. 