### PR TITLE
design: 로그 화면의 문자열 수정

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,18 +2,18 @@
     <string name="app_name">오디</string>
 
     <!-- fcm_notification -->
-    <string name="fcm_notification_entry">%s (이)가 들어왔어요.</string>
-    <string name="fcm_notification_departure_reminder">%s (이)가 출발할 시간이에요!</string>
-    <string name="fcm_notification_nudge">"\uD83D\uDC40 %s(이)가 재촉해요."</string>
+    <string name="fcm_notification_entry">%s님이 들어왔어요.</string>
+    <string name="fcm_notification_departure_reminder">%s님이 출발할 시간이에요!</string>
+    <string name="fcm_notification_nudge">\uD83D\uDC40 %s님이 재촉해요.</string>
     <string name="fcm_notification_eta_notice">"%s 약속에 참여한 친구 위치를 확인해 보세요!"</string>
 
     <!-- item_notification_log.xml -->
-    <string name="item_notification_entry">(이)가 들어왔어요.</string>
-    <string name="item_notification_departure_reminder">(이)가 출발할 시간이에요!</string>
-    <string name="item_notification_departure">(이)가 출발했어요.</string>
-    <string name="item_notification_nudge">"(이)가 재촉 받았어요. \uD83D\uDC40"</string>
-    <string name="item_notification_member_deletion">(이)가 오디를 떠났어요.</string>
-    <string name="item_notification_member_exit">(이)가 나갔어요.</string>
+    <string name="item_notification_entry">님이 들어왔어요.</string>
+    <string name="item_notification_departure_reminder">님이 출발할 시간이에요!</string>
+    <string name="item_notification_departure">님이 출발했어요.</string>
+    <string name="item_notification_nudge">님이 재촉 받았어요. \uD83D\uDC40</string>
+    <string name="item_notification_member_deletion">님이 오디를 떠났어요.</string>
+    <string name="item_notification_member_exit">님이 나갔어요.</string>
     <string name="item_notification_default"> </string>
 
     <!-- activity_meeting_room.xml -->


### PR DESCRIPTION
# 🚩 연관 이슈 
close #751


<br>

# 📝 작업 내용


<br>

# 🏞️ 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/f1d9a95c-1a7f-4ea2-b3b3-c525e3310466" width="300">


<br>

# 🗣️ 리뷰 요구사항 (선택)
푸시 알림 문자열과 로그 화면 문자열에 있는 `~이가`를 `~님이`로 변경했습니다.
그런데 닉네임 뒤에 `님`을 붙이면서, `친구`라는 단어도 안 쓰는 쪽으로 수정해야 조금 더 자연스러울 것 같아요.
`친구` 단어를 사용한 문자열들은 아래와 같습니다.
```
- %s 약속에 참여한 친구 위치를 확인해 보세요!
- 초대 코드를 복사해 친구에게 전달해 보세요!
- 위치 권한을 거절하면 내 위치를 친구에게 공유할 수 없어요
- 친구의 위치 권한이 꺼져있어요.
- 친구들의 도착 예정 정보를 확인해보세요!
- 친구와 도착 정보를 공유하고 있어요.
- 지각 위기 버튼을 눌러 친구를 재촉해 보세요.
- 약속 시간 30분 전부터 친구들의 위치 현황을 확인해 보세요.
- 지각 버튼을 눌러 친구를 재촉해 보세요.
- 약속 시간 이후부터는 친구들의 지각 여부를 확인할 수 있어요.
```
이 `친구`를 어떤 단어로 대체할지 아직 잘 모르겠어요.. 어떤 걸 대입해도 조금 어색해요.
그래서 emergency 채널에 `<~님 + 친구를 다른 단어로 대체하기>` or `<변경하지 말기(~이가 + 친구 그대로)>` 이 두 가지를 투표 받으려고 합니다.

일단 수정한 부분 PR은 올려두겠습니다!