### PR TITLE
fix: 안드로이드 cd 배포 시 개인정보 페이지 열리지 않는 문제 수정

### DIFF
--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -56,7 +56,7 @@ jobs:
           echo "KAKAO_API_KEY=\"$KAKAO_API_KEY\"" >> ./local.properties
           echo "KAKAO_NATIVE_KEY=\"$KAKAO_NATIVE_KEY\"" >> ./local.properties
           echo "TERM_URI=\"$TERM_URI\"" >> ./local.properties
-          echo "PRIVACY_POLICY_URL=\"$PRIVACY_POLICY_URI\"" >> ./local.properties
+          echo "PRIVACY_POLICY_URI=\"$PRIVACY_POLICY_URI\"" >> ./local.properties
 
       - name: Change gradlew permissions
         run: chmod +x ./gradlew


### PR DESCRIPTION
# 🚩 연관 이슈 
close #862


<br>

# 📝 작업 내용
- [x] cd 스크립트 오타 수정

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
URI를 URL로 적었네요. 하.. -_-
main 브랜치에 있는 cd 스크립트를 앞서 수정했는데 반영되지 않아서 살펴봤는데요,
develop 브랜치에 있는 스크립트를 실행하는 것으로 보입니다. 아마 default 브랜치가 develop이라서 그런듯
