### PR TITLE
fix: 안드로이드 cd 배포 시 개인정보 페이지 열리지 않는 문제 수정

### DIFF
--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -49,7 +49,7 @@ jobs:
           KAKAO_API_KEY: ${{secrets.KAKAO_API_KEY}}
           KAKAO_NATIVE_KEY: ${{secrets.KAKAO_NATIVE_KEY}}
           TERM_URI: ${{secrets.TERM_URI}}
-          PRIVACY_POLICY_URL: ${{secrets.PRIVACY_POLICY_URI}}
+          PRIVACY_POLICY_URI: ${{secrets.PRIVACY_POLICY_URI}}
         run: |
           echo "BASE_DEV_URL=\"$BASE_DEV_URL\"" >> ./local.properties
           echo "BASE_PROD_URL=\"$BASE_PROD_URL\"" >> ./local.properties


### PR DESCRIPTION
# 🚩 연관 이슈 
close #862


<br>

# 📝 작업 내용
- [x] cd 스크립트 오타 수정

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
