### PR TITLE
fix: 약속 참여할 때 가끔 바로 로그화면으로 가지지 않는 버그 수정

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinActivity.kt
@@ -112,8 +112,7 @@ class MeetingJoinActivity :
     }
 
     override fun onNext() {
-        viewModel.joinMeeting(getInviteCode())
-        viewModel.onClickMeetingJoin()
+        viewModel.onClickMeetingJoin(getInviteCode())
     }
 
     override fun onBack() = finish()

--- a/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinActivity.kt
@@ -19,7 +19,6 @@ import com.mulberry.ody.presentation.join.complete.JoinCompleteActivity
 import com.mulberry.ody.presentation.launchWhenStarted
 import com.mulberry.ody.presentation.room.MeetingRoomActivity
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinActivity.kt
@@ -62,7 +62,7 @@ class MeetingJoinActivity :
                 }
             }
             launch {
-                viewModel.navigateAction.conflate().collect {
+                viewModel.navigateAction.collect {
                     when (it) {
                         is MeetingJoinNavigateAction.JoinNavigateToRoom -> {
                             navigateToNotificationRoom(it.meetingId)

--- a/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinViewModel.kt
@@ -96,6 +96,10 @@ class MeetingJoinViewModel
             }
         }
 
+        override fun onClickMeetingJoin(inviteCode: String) {
+            joinMeeting(inviteCode)
+        }
+
         private fun joinMeeting(inviteCode: String) {
             val meetingJoinInfo = createMeetingJoinInfo(inviteCode) ?: return
 
@@ -131,10 +135,6 @@ class MeetingJoinViewModel
             return AddressValidator.isValid(departureAddress.detailAddress).also {
                 if (!it) _invalidDepartureEvent.emit(Unit)
             }
-        }
-
-        override fun onClickMeetingJoin(inviteCode: String) {
-            joinMeeting(inviteCode)
         }
 
         companion object {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinViewModel.kt
@@ -54,7 +54,8 @@ class MeetingJoinViewModel
                     initialValue = false,
                 )
 
-        private val _navigateAction: MutableSharedFlow<MeetingJoinNavigateAction> = MutableSharedFlow(replay = 1)
+        private val _navigateAction: MutableSharedFlow<MeetingJoinNavigateAction> =
+            MutableSharedFlow(replay = 1)
         val navigateAction: SharedFlow<MeetingJoinNavigateAction> get() = _navigateAction.asSharedFlow()
 
         private val _defaultLocationError: MutableSharedFlow<Unit> = MutableSharedFlow()
@@ -95,7 +96,7 @@ class MeetingJoinViewModel
             }
         }
 
-        fun joinMeeting(inviteCode: String) {
+        private fun joinMeeting(inviteCode: String) {
             val meetingJoinInfo = createMeetingJoinInfo(inviteCode) ?: return
 
             viewModelScope.launch {
@@ -104,6 +105,7 @@ class MeetingJoinViewModel
                     .suspendOnSuccess {
                         matesEtaRepository.reserveEtaFetchingJob(it.meetingId, it.meetingDateTime)
                         _navigateAction.emit(MeetingJoinNavigateAction.JoinNavigateToRoom(it.meetingId))
+                        _navigateAction.emit(MeetingJoinNavigateAction.JoinNavigateToJoinComplete)
                     }.onFailure { code, errorMessage ->
                         handleError()
                         analyticsHelper.logNetworkErrorEvent(TAG, "$code $errorMessage")
@@ -131,10 +133,8 @@ class MeetingJoinViewModel
             }
         }
 
-        override fun onClickMeetingJoin() {
-            viewModelScope.launch {
-                _navigateAction.emit(MeetingJoinNavigateAction.JoinNavigateToJoinComplete)
-            }
+        override fun onClickMeetingJoin(inviteCode: String) {
+            joinMeeting(inviteCode)
         }
 
         companion object {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinViewModel.kt
@@ -54,7 +54,7 @@ class MeetingJoinViewModel
                     initialValue = false,
                 )
 
-        private val _navigateAction: MutableSharedFlow<MeetingJoinNavigateAction> = MutableSharedFlow()
+        private val _navigateAction: MutableSharedFlow<MeetingJoinNavigateAction> = MutableSharedFlow(replay = 1)
         val navigateAction: SharedFlow<MeetingJoinNavigateAction> get() = _navigateAction.asSharedFlow()
 
         private val _defaultLocationError: MutableSharedFlow<Unit> = MutableSharedFlow()

--- a/android/app/src/main/java/com/mulberry/ody/presentation/join/listener/MeetingJoinListener.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/join/listener/MeetingJoinListener.kt
@@ -1,5 +1,5 @@
 package com.mulberry.ody.presentation.join.listener
 
 interface MeetingJoinListener {
-    fun onClickMeetingJoin()
+    fun onClickMeetingJoin(inviteCode: String)
 }

--- a/android/app/src/test/java/com/mulberry/ody/presentation/join/MeetingJoinViewModelTest.kt
+++ b/android/app/src/test/java/com/mulberry/ody/presentation/join/MeetingJoinViewModelTest.kt
@@ -45,7 +45,7 @@ class MeetingJoinViewModelTest {
             // when
             val actual =
                 viewModel.navigateAction.valueOnAction {
-                    viewModel.joinMeeting("abc123")
+                    viewModel.onClickMeetingJoin("abc123")
                 }
 
             // then
@@ -57,7 +57,7 @@ class MeetingJoinViewModelTest {
     fun `입력하지 않은 값이 있는 경우 약속 참여할 수 없다`() {
         runTest {
             // when
-            viewModel.joinMeeting("abc123")
+            viewModel.onClickMeetingJoin("abc123")
 
             // then
             val actual = viewModel.navigateAction.valueOnAction {}


### PR DESCRIPTION
# 🚩 연관 이슈 
close #851 


<br>

# 📝 작업 내용
- [x] 약속 참여할 때 가끔 바로 로그화면으로 가지지 않는 버그 수정

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
replay가 없어서 Flow가 최근에 발행한 값을 다시 새로운 구독자에게 제공할 수 있도록 설정했습니다. UI 컴포넌트가 다시 구독할 때 이전 상태를 잃지 않고 최신 상태를 유지할 수 있게 했습니다.
conflate는 필요성을 못느껴서 삭제했습니다!. 그리고 onClick에서 두 메서드를 부르는게 어색하고 디버깅이 어려워서 클릭메서드 호출로 변경했습니다.
이상한 점 있으면 말씀해주세요!