### PR TITLE
fix: 나갔던 약속에 재참여가 되지 않는 문제 개선

### DIFF
--- a/backend/src/main/java/com/ody/mate/domain/Mate.java
+++ b/backend/src/main/java/com/ody/mate/domain/Mate.java
@@ -27,8 +27,8 @@ import org.hibernate.annotations.SQLDelete;
 
 @Table(uniqueConstraints = {
         @UniqueConstraint(
-                name = "uniqueMeetingAndMember",
-                columnNames = {"meeting_id", "member_id"}
+                name = "uniqueMeetingAndMemberAndDeletedAt",
+                columnNames = {"meeting_id", "member_id", "deleted_at"}
         )
 })
 @Entity

--- a/backend/src/test/java/com/ody/mate/controller/MateControllerTest.java
+++ b/backend/src/test/java/com/ody/mate/controller/MateControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.http.HttpHeaders;
 
 class MateControllerTest extends BaseControllerTest {
 
-
     @DisplayName("동일 약속에 퇴장했다가 재참여가 가능하다")
     @TestFactory
     Stream<DynamicTest> canReattendMeeting() {
@@ -26,18 +25,6 @@ class MateControllerTest extends BaseControllerTest {
         Member member = fixtureGenerator.generateMember();
 
         return Stream.of(
-                dynamicTest("약속에 최초 참여한다", () -> {
-                    MateSaveRequestV2 mateSaveRequestV2 = dtoGenerator.generateMateSaveRequest(meeting);
-                    RestAssured.given().log().all()
-                            .contentType(ContentType.JSON)
-                            .header(HttpHeaders.AUTHORIZATION,
-                                    fixtureGenerator.generateAccessTokenValueByMember(member))
-                            .body(mateSaveRequestV2)
-                            .when()
-                            .post("/v2/mates")
-                            .then()
-                            .statusCode(201);
-                }),
                 dynamicTest("약속에 최초 참여한다", () -> {
                     MateSaveRequestV2 mateSaveRequestV2 = dtoGenerator.generateMateSaveRequest(meeting);
                     RestAssured.given().log().all()
@@ -72,4 +59,38 @@ class MateControllerTest extends BaseControllerTest {
         );
     }
 
+    @DisplayName("약속에 참여한 상태로 재참여가 불가하다")
+    @TestFactory
+    Stream<DynamicTest> canNotReattendMeetingWithoutLeave() {
+        LocalDateTime fiveMinutesLater = LocalDateTime.now().plusMinutes(5L);
+        Meeting meeting = fixtureGenerator.generateMeeting(fiveMinutesLater);
+        Member member = fixtureGenerator.generateMember();
+
+        return Stream.of(
+                dynamicTest("약속에 최초 참여한다", () -> {
+                    MateSaveRequestV2 mateSaveRequestV2 = dtoGenerator.generateMateSaveRequest(meeting);
+                    RestAssured.given().log().all()
+                            .contentType(ContentType.JSON)
+                            .header(HttpHeaders.AUTHORIZATION,
+                                    fixtureGenerator.generateAccessTokenValueByMember(member))
+                            .body(mateSaveRequestV2)
+                            .when()
+                            .post("/v2/mates")
+                            .then()
+                            .statusCode(201);
+                }),
+                dynamicTest("동일 약속에 재참여를 시도한다", () -> {
+                    MateSaveRequestV2 mateSaveRequestV2 = dtoGenerator.generateMateSaveRequest(meeting);
+                    RestAssured.given().log().all()
+                            .contentType(ContentType.JSON)
+                            .header(HttpHeaders.AUTHORIZATION,
+                                    fixtureGenerator.generateAccessTokenValueByMember(member))
+                            .body(mateSaveRequestV2)
+                            .when()
+                            .post("/v2/mates")
+                            .then()
+                            .statusCode(400);
+                })
+        );
+    };
 }

--- a/backend/src/test/java/com/ody/mate/controller/MateControllerTest.java
+++ b/backend/src/test/java/com/ody/mate/controller/MateControllerTest.java
@@ -1,0 +1,75 @@
+package com.ody.mate.controller;
+
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+import com.ody.common.BaseControllerTest;
+import com.ody.mate.dto.request.MateSaveRequestV2;
+import com.ody.meeting.domain.Meeting;
+import com.ody.member.domain.Member;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.http.HttpHeaders;
+
+class MateControllerTest extends BaseControllerTest {
+
+
+    @DisplayName("동일 약속에 퇴장했다가 재참여가 가능하다")
+    @TestFactory
+    Stream<DynamicTest> canReattendMeeting() {
+        LocalDateTime fiveMinutesLater = LocalDateTime.now().plusMinutes(5L);
+        Meeting meeting = fixtureGenerator.generateMeeting(fiveMinutesLater);
+        Member member = fixtureGenerator.generateMember();
+
+        return Stream.of(
+                dynamicTest("약속에 최초 참여한다", () -> {
+                    MateSaveRequestV2 mateSaveRequestV2 = dtoGenerator.generateMateSaveRequest(meeting);
+                    RestAssured.given().log().all()
+                            .contentType(ContentType.JSON)
+                            .header(HttpHeaders.AUTHORIZATION,
+                                    fixtureGenerator.generateAccessTokenValueByMember(member))
+                            .body(mateSaveRequestV2)
+                            .when()
+                            .post("/v2/mates")
+                            .then()
+                            .statusCode(201);
+                }),
+                dynamicTest("약속에 최초 참여한다", () -> {
+                    MateSaveRequestV2 mateSaveRequestV2 = dtoGenerator.generateMateSaveRequest(meeting);
+                    RestAssured.given().log().all()
+                            .contentType(ContentType.JSON)
+                            .header(HttpHeaders.AUTHORIZATION, fixtureGenerator.generateAccessTokenValueByMember(member))
+                            .body(mateSaveRequestV2)
+                            .when()
+                            .post("/v2/mates")
+                            .then()
+                            .statusCode(201);
+                }),
+                dynamicTest("약속에서 퇴장한다", () -> {
+                    RestAssured.given().log().all()
+                            .contentType(ContentType.JSON)
+                            .header(HttpHeaders.AUTHORIZATION, fixtureGenerator.generateAccessTokenValueByMember(member))
+                            .when()
+                            .delete("/meetings/" + meeting.getId() + "/mate")
+                            .then()
+                            .statusCode(204);
+                }),
+                dynamicTest("약속에 재참여한다", () -> {
+                    MateSaveRequestV2 mateSaveRequestV2 = dtoGenerator.generateMateSaveRequest(meeting);
+                    RestAssured.given().log().all()
+                            .contentType(ContentType.JSON)
+                            .header(HttpHeaders.AUTHORIZATION, fixtureGenerator.generateAccessTokenValueByMember(member))
+                            .body(mateSaveRequestV2)
+                            .when()
+                            .post("/v2/mates")
+                            .then()
+                            .statusCode(201);
+                })
+        );
+    }
+
+}


### PR DESCRIPTION
# 🚩 연관 이슈 
close #879 


<br>

# 📝 작업 내용
- meeting_member unique 조건 > meeting_member_deleteAt unique 조건으로 변경

기존에 약속-회원의 유니크 조건으로인해 퇴장했던 약속에 재참여가 불가하다는 이슈가 발생했습니다.
그렇다고 이 조건을 해제해버리면 동일 약속에 회원이 무한대로 재참여할 수 있게 되는 문제가 발생합니다.
![image](https://github.com/user-attachments/assets/28d91c7c-9b45-4ed5-be4b-c667adc028c6)


따라서 **유니크 조건에 삭제 여부를 같이 걸어서 퇴장했던 약속의 재참여를 가능하게 하되 퇴장하지 않은 참여자의 경우 재참여를 불가하도록 설정**하였습니다.


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)

테스트는 유저 행동 시나리오라고 생각하여 dynamicTest로 인수 테스트를 작성하였습니다.
불필요한 작업이라 생각되면 단위 테스트로 바꿀 예정이니 의견 남겨주세요.
