### PR TITLE
fix: 약속을 나간 경우에도 eta 폴링 요청을 계속 보내는 버그 수정

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/data/local/repository/DefaultMatesEtaRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/repository/DefaultMatesEtaRepository.kt
@@ -67,6 +67,8 @@ class DefaultMatesEtaRepository
         override suspend fun deleteEtaReservation(meetingId: Long) {
             etaDashboardAlarm.cancelByMeetingId(meetingId)
             etaReservationDao.delete(meetingId)
+            val serviceIntent = EtaDashboardService.getIntent(context, meetingId, isOpen = false)
+            context.startForegroundService(serviceIntent)
         }
 
         override suspend fun clearEtaReservation(isReservationPending: Boolean) {


### PR DESCRIPTION
# 🚩 연관 이슈 
close #881

<br>

# 📝 작업 내용


<br>

# 🏞️ 스크린샷 (선택)

https://github.com/user-attachments/assets/f4fb9a0a-184f-4852-8a37-5e59c5be9fe3


약속 나간 경우 foreground service 알림이 없어지는지 확인하는 영상입니다

<br>

# 🗣️ 리뷰 요구사항 (선택)
reservation 엔티티는 삭제하는 코드는 작성했었는데
service stop하는 코드를 놓쳤네요..!!!