### PR TITLE
fix: 앱 업데이트 및 재부팅 시 alarm 등록하는 BroadcastReceiver 추가

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-configuration android:name="android:permission.POST_NOTIFICATIONS" />
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
@@ -128,7 +129,14 @@
 
         <receiver android:name=".data.local.service.EtaDashboardOpenBroadcastReceiver" />
         <receiver android:name=".data.local.service.EtaDashboardCloseBroadcastReceiver" />
-
+        <receiver
+            android:name=".data.local.service.ReinstallBroadcastReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/mulberry/ody/data/local/repository/DefaultMatesEtaRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/repository/DefaultMatesEtaRepository.kt
@@ -1,7 +1,6 @@
 package com.mulberry.ody.data.local.repository
 
 import android.content.Context
-import android.util.Log
 import com.mulberry.ody.data.local.db.EtaReservationDao
 import com.mulberry.ody.data.local.db.MateEtaInfoDao
 import com.mulberry.ody.data.local.entity.eta.MateEtaInfoEntity
@@ -83,7 +82,6 @@ class DefaultMatesEtaRepository
 
         override suspend fun reserveAllEtaReservation() {
             val entities = etaReservationDao.fetchAll()
-            Log.e("TEST", "reserveAllEtaReservation ${entities.size}")
             entities.forEach { entity ->
                 etaDashboardAlarm.reserve(
                     entity.meetingId,

--- a/android/app/src/main/java/com/mulberry/ody/data/local/repository/DefaultMatesEtaRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/repository/DefaultMatesEtaRepository.kt
@@ -1,6 +1,7 @@
 package com.mulberry.ody.data.local.repository
 
 import android.content.Context
+import android.util.Log
 import com.mulberry.ody.data.local.db.EtaReservationDao
 import com.mulberry.ody.data.local.db.MateEtaInfoDao
 import com.mulberry.ody.data.local.entity.eta.MateEtaInfoEntity
@@ -82,6 +83,7 @@ class DefaultMatesEtaRepository
 
         override suspend fun reserveAllEtaReservation() {
             val entities = etaReservationDao.fetchAll()
+            Log.e("TEST", "reserveAllEtaReservation ${entities.size}")
             entities.forEach { entity ->
                 etaDashboardAlarm.reserve(
                     entity.meetingId,

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardCloseBroadcastReceiver.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardCloseBroadcastReceiver.kt
@@ -6,15 +6,16 @@ import android.content.Intent
 import com.mulberry.ody.data.local.service.EtaDashboardService.Companion.MEETING_ID_DEFAULT_VALUE
 import com.mulberry.ody.data.local.service.EtaDashboardService.Companion.MEETING_ID_KEY
 import com.mulberry.ody.domain.repository.ody.MatesEtaRepository
-import dagger.hilt.EntryPoint
-import dagger.hilt.InstallIn
-import dagger.hilt.android.EntryPointAccessors
-import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class EtaDashboardCloseBroadcastReceiver : BroadcastReceiver() {
+    @Inject
+    lateinit var matesEtaRepository: MatesEtaRepository
     private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 
     override fun onReceive(
@@ -24,30 +25,11 @@ class EtaDashboardCloseBroadcastReceiver : BroadcastReceiver() {
         val meetingId = intent.getLongExtra(MEETING_ID_KEY, MEETING_ID_DEFAULT_VALUE)
         if (meetingId == MEETING_ID_DEFAULT_VALUE) return
 
-        val matesEtaRepository =
-            EtaDashboardCloseBroadcastReceiverEntryPoint.matesEtaRepository(context)
         coroutineScope.launch {
             matesEtaRepository.deleteEtaReservation(meetingId)
         }
 
         val serviceIntent = EtaDashboardService.getIntent(context, meetingId, isOpen = false)
         context.startForegroundService(serviceIntent)
-    }
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface EtaDashboardCloseBroadcastReceiverEntryPoint {
-        fun matesEtaRepository(): MatesEtaRepository
-
-        companion object {
-            fun matesEtaRepository(context: Context): MatesEtaRepository {
-                return EntryPointAccessors
-                    .fromApplication(
-                        context,
-                        EtaDashboardCloseBroadcastReceiverEntryPoint::class.java,
-                    )
-                    .matesEtaRepository()
-            }
-        }
     }
 }

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardCloseBroadcastReceiver.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardCloseBroadcastReceiver.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 class EtaDashboardCloseBroadcastReceiver : BroadcastReceiver() {
     @Inject
     lateinit var matesEtaRepository: MatesEtaRepository
-    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 
     override fun onReceive(
         context: Context,

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardCloseBroadcastReceiver.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardCloseBroadcastReceiver.kt
@@ -6,14 +6,15 @@ import android.content.Intent
 import com.mulberry.ody.data.local.service.EtaDashboardService.Companion.MEETING_ID_DEFAULT_VALUE
 import com.mulberry.ody.data.local.service.EtaDashboardService.Companion.MEETING_ID_KEY
 import com.mulberry.ody.domain.repository.ody.MatesEtaRepository
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 class EtaDashboardCloseBroadcastReceiver : BroadcastReceiver() {
-    @Inject
-    lateinit var matesEtaRepository: MatesEtaRepository
     private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 
     override fun onReceive(
@@ -23,11 +24,30 @@ class EtaDashboardCloseBroadcastReceiver : BroadcastReceiver() {
         val meetingId = intent.getLongExtra(MEETING_ID_KEY, MEETING_ID_DEFAULT_VALUE)
         if (meetingId == MEETING_ID_DEFAULT_VALUE) return
 
+        val matesEtaRepository =
+            EtaDashboardCloseBroadcastReceiverEntryPoint.matesEtaRepository(context)
         coroutineScope.launch {
             matesEtaRepository.deleteEtaReservation(meetingId)
         }
 
         val serviceIntent = EtaDashboardService.getIntent(context, meetingId, isOpen = false)
         context.startForegroundService(serviceIntent)
+    }
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface EtaDashboardCloseBroadcastReceiverEntryPoint {
+        fun matesEtaRepository(): MatesEtaRepository
+
+        companion object {
+            fun matesEtaRepository(context: Context): MatesEtaRepository {
+                return EntryPointAccessors
+                    .fromApplication(
+                        context,
+                        EtaDashboardCloseBroadcastReceiverEntryPoint::class.java,
+                    )
+                    .matesEtaRepository()
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardCloseBroadcastReceiver.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardCloseBroadcastReceiver.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
 class EtaDashboardCloseBroadcastReceiver : BroadcastReceiver() {
     @Inject
     lateinit var matesEtaRepository: MatesEtaRepository
-    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
     override fun onReceive(
         context: Context,

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/ReinstallBroadcastReceiver.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/ReinstallBroadcastReceiver.kt
@@ -3,7 +3,6 @@ package com.mulberry.ody.data.local.service
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import com.mulberry.ody.domain.repository.ody.MatesEtaRepository
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
@@ -20,11 +19,7 @@ class ReinstallBroadcastReceiver : BroadcastReceiver() {
         context: Context,
         intent: Intent,
     ) {
-        Log.e("TEST", "${intent.action}")
-        val matesEtaRepository =
-            EntryPointAccessors
-                .fromApplication(context, ReinstallBroadcastReceiverEntryPoint::class.java)
-                .matesEtaRepository()
+        val matesEtaRepository = ReinstallBroadcastReceiverEntryPoint.matesEtaRepository(context)
         coroutineScope.launch {
             matesEtaRepository.reserveAllEtaReservation()
         }
@@ -34,5 +29,13 @@ class ReinstallBroadcastReceiver : BroadcastReceiver() {
     @InstallIn(SingletonComponent::class)
     interface ReinstallBroadcastReceiverEntryPoint {
         fun matesEtaRepository(): MatesEtaRepository
+
+        companion object {
+            fun matesEtaRepository(context: Context): MatesEtaRepository {
+                return EntryPointAccessors
+                    .fromApplication(context, ReinstallBroadcastReceiverEntryPoint::class.java)
+                    .matesEtaRepository()
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/ReinstallBroadcastReceiver.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/ReinstallBroadcastReceiver.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 class ReinstallBroadcastReceiver : BroadcastReceiver() {
     @Inject
     lateinit var matesEtaRepository: MatesEtaRepository
-    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
     override fun onReceive(
         context: Context,

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/ReinstallBroadcastReceiver.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/ReinstallBroadcastReceiver.kt
@@ -27,7 +27,7 @@ class ReinstallBroadcastReceiver : BroadcastReceiver() {
 
     @EntryPoint
     @InstallIn(SingletonComponent::class)
-    private interface ReinstallBroadcastReceiverEntryPoint {
+    interface ReinstallBroadcastReceiverEntryPoint {
         fun matesEtaRepository(): MatesEtaRepository
 
         companion object {

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/ReinstallBroadcastReceiver.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/ReinstallBroadcastReceiver.kt
@@ -1,0 +1,38 @@
+package com.mulberry.ody.data.local.service
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.mulberry.ody.domain.repository.ody.MatesEtaRepository
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class ReinstallBroadcastReceiver : BroadcastReceiver() {
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        Log.e("TEST", "${intent.action}")
+        val matesEtaRepository =
+            EntryPointAccessors
+                .fromApplication(context, ReinstallBroadcastReceiverEntryPoint::class.java)
+                .matesEtaRepository()
+        coroutineScope.launch {
+            matesEtaRepository.reserveAllEtaReservation()
+        }
+    }
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface ReinstallBroadcastReceiverEntryPoint {
+        fun matesEtaRepository(): MatesEtaRepository
+    }
+}

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/ReinstallBroadcastReceiver.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/ReinstallBroadcastReceiver.kt
@@ -4,38 +4,24 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.mulberry.ody.domain.repository.ody.MatesEtaRepository
-import dagger.hilt.EntryPoint
-import dagger.hilt.InstallIn
-import dagger.hilt.android.EntryPointAccessors
-import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class ReinstallBroadcastReceiver : BroadcastReceiver() {
+    @Inject
+    lateinit var matesEtaRepository: MatesEtaRepository
     private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 
     override fun onReceive(
         context: Context,
         intent: Intent,
     ) {
-        val matesEtaRepository = ReinstallBroadcastReceiverEntryPoint.matesEtaRepository(context)
         coroutineScope.launch {
             matesEtaRepository.reserveAllEtaReservation()
-        }
-    }
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface ReinstallBroadcastReceiverEntryPoint {
-        fun matesEtaRepository(): MatesEtaRepository
-
-        companion object {
-            fun matesEtaRepository(context: Context): MatesEtaRepository {
-                return EntryPointAccessors
-                    .fromApplication(context, ReinstallBroadcastReceiverEntryPoint::class.java)
-                    .matesEtaRepository()
-            }
         }
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #899 


<br>

# 📝 작업 내용


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
안드로이드는 앱 업데이트 하면 AlarmManager의 스케줄링들이 모두 삭제된다고 해요.
앱 업데이트를 트리거할 수 있는 BroadcastReceiver를 등록하고, 이 BroadcastReceiver에서 Room에 저장된 스케줄링들을 다시 AlarmManager에 등록하는 코드 구현했습니다!
개발하면서 재부팅 시에도 AlarmManager 스케줄링 재등록하도록 추가했어요
이 글을 참고했습니다. -> https://stackoverflow.com/questions/49704914/alarmmanager-when-app-is-updated