### PR TITLE
refactor: 초대코드 유효하지 않은 메시지 서버로부터 받게 변경

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/data/remote/core/entity/ErrorResponse.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/core/entity/ErrorResponse.kt
@@ -1,0 +1,18 @@
+package com.mulberry.ody.data.remote.core.entity
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ErrorResponse(
+    @Json(name = "type")
+    val type: String,
+    @Json(name = "title")
+    val title: String,
+    @Json(name = "status")
+    val status: Int,
+    @Json(name = "detail")
+    val detail: String,
+    @Json(name = "instance")
+    val instance: String,
+)

--- a/android/app/src/main/java/com/mulberry/ody/domain/apiresult/ApiResult.kt
+++ b/android/app/src/main/java/com/mulberry/ody/domain/apiresult/ApiResult.kt
@@ -5,7 +5,7 @@ import java.io.IOException
 sealed interface ApiResult<out T> {
     data class Success<T>(val data: T) : ApiResult<T>
 
-    data class Failure(val code: Int, val errorMessage: String?) : ApiResult<Nothing>
+    data class Failure(val code: Int?, val errorMessage: String?) : ApiResult<Nothing>
 
     data class NetworkError(val exception: IOException) : ApiResult<Nothing>
 

--- a/android/app/src/main/java/com/mulberry/ody/domain/apiresult/ApiResultExtensions.kt
+++ b/android/app/src/main/java/com/mulberry/ody/domain/apiresult/ApiResultExtensions.kt
@@ -7,7 +7,7 @@ fun <T> ApiResult<T>.onSuccess(block: (T) -> Unit): ApiResult<T> {
     return this
 }
 
-fun <T> ApiResult<T>.onFailure(block: (code: Int, errorMessage: String?) -> Unit): ApiResult<T> {
+fun <T> ApiResult<T>.onFailure(block: (code: Int?, errorMessage: String?) -> Unit): ApiResult<T> {
     if (this is ApiResult.Failure) {
         block(this.code, this.errorMessage)
     }
@@ -35,7 +35,7 @@ suspend fun <T> ApiResult<T>.suspendOnSuccess(block: suspend (T) -> Unit): ApiRe
     return this
 }
 
-suspend fun <T> ApiResult<T>.suspendOnFailure(block: suspend (code: Int, errorMessage: String?) -> Unit): ApiResult<T> {
+suspend fun <T> ApiResult<T>.suspendOnFailure(block: suspend (code: Int?, errorMessage: String?) -> Unit): ApiResult<T> {
     if (this is ApiResult.Failure) {
         block(this.code, this.errorMessage)
     }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/common/binding/BindingActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/common/binding/BindingActivity.kt
@@ -40,6 +40,19 @@ abstract class BindingActivity<T : ViewDataBinding>(
         snackBar?.show()
     }
 
+    protected fun showSnackBar(
+        message: String,
+        @StringRes actionMessageId: Int? = null,
+        action: () -> Unit = {},
+    ) {
+        snackBar?.dismiss()
+        snackBar = Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT)
+        actionMessageId?.let {
+            snackBar?.setAction(actionMessageId) { action() }
+        }
+        snackBar?.show()
+    }
+
     protected fun showRetrySnackBar(action: () -> Unit) {
         snackBar?.dismiss()
         snackBar =

--- a/android/app/src/main/java/com/mulberry/ody/presentation/invitecode/InviteCodeActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/invitecode/InviteCodeActivity.kt
@@ -29,7 +29,7 @@ class InviteCodeActivity :
     }
 
     private fun initializeObserve() {
-        collectWhenStarted(viewModel.invitationCodeEvent) { errorMmessage ->
+        collectWhenStarted(viewModel.invalidCodeEvent) { errorMmessage ->
             viewModel.clearInviteCode()
             showSnackBar(errorMmessage)
         }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/invitecode/InviteCodeActivity.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/invitecode/InviteCodeActivity.kt
@@ -29,13 +29,9 @@ class InviteCodeActivity :
     }
 
     private fun initializeObserve() {
-        collectWhenStarted(viewModel.alreadyParticipatedEvent) {
+        collectWhenStarted(viewModel.invitationCodeEvent) { errorMmessage ->
             viewModel.clearInviteCode()
-            showSnackBar(R.string.invite_code_already_participated)
-        }
-        collectWhenStarted(viewModel.invalidInviteCodeEvent) {
-            viewModel.clearInviteCode()
-            showSnackBar(R.string.invite_code_invalid_invite_code)
+            showSnackBar(errorMmessage)
         }
         collectWhenStarted(viewModel.navigateAction) {
             navigateToJoinView()
@@ -56,7 +52,7 @@ class InviteCodeActivity :
     }
 
     private fun navigateToJoinView() {
-        val inviteCode = viewModel.inviteCode.value ?: return
+        val inviteCode = viewModel.inviteCode.value
         startActivity(MeetingJoinActivity.getIntent(inviteCode, this))
     }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/invitecode/InviteCodeViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/invitecode/InviteCodeViewModel.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -37,11 +36,8 @@ class InviteCodeViewModel
                     initialValue = false,
                 )
 
-        private val _invalidInviteCodeEvent: MutableSharedFlow<Unit> = MutableSharedFlow()
-        val invalidInviteCodeEvent: SharedFlow<Unit> get() = _invalidInviteCodeEvent.asSharedFlow()
-
-        private val _alreadyParticipatedEvent: MutableSharedFlow<Unit> = MutableSharedFlow()
-        val alreadyParticipatedEvent: SharedFlow<Unit> get() = _alreadyParticipatedEvent.asSharedFlow()
+        private val _invitationCodeEvent: MutableSharedFlow<String> = MutableSharedFlow()
+        val invitationCodeEvent: SharedFlow<String> get() = _invitationCodeEvent.asSharedFlow()
 
         private val _navigateAction: MutableSharedFlow<InviteCodeNavigateAction> = MutableSharedFlow()
         val navigateAction: SharedFlow<InviteCodeNavigateAction> get() = _navigateAction.asSharedFlow()
@@ -58,12 +54,8 @@ class InviteCodeViewModel
                     .suspendOnSuccess {
                         _navigateAction.emit(InviteCodeNavigateAction.CodeNavigateToJoin)
                     }.suspendOnFailure { code, errorMessage ->
-                        when (code) {
-                            400 -> _alreadyParticipatedEvent.emit(Unit)
-                            404 -> _invalidInviteCodeEvent.emit(Unit)
-                        }
+                        _invitationCodeEvent.emit(errorMessage.toString())
                         analyticsHelper.logNetworkErrorEvent(TAG, "$code $errorMessage")
-                        Timber.e("$code $errorMessage")
                     }.onNetworkError {
                         handleNetworkError()
                         lastFailedAction = { checkInviteCode() }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/invitecode/InviteCodeViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/invitecode/InviteCodeViewModel.kt
@@ -36,8 +36,8 @@ class InviteCodeViewModel
                     initialValue = false,
                 )
 
-        private val _invitationCodeEvent: MutableSharedFlow<String> = MutableSharedFlow()
-        val invitationCodeEvent: SharedFlow<String> get() = _invitationCodeEvent.asSharedFlow()
+        private val _invalidCodeEvent: MutableSharedFlow<String> = MutableSharedFlow()
+        val invalidCodeEvent: SharedFlow<String> get() = _invalidCodeEvent.asSharedFlow()
 
         private val _navigateAction: MutableSharedFlow<InviteCodeNavigateAction> = MutableSharedFlow()
         val navigateAction: SharedFlow<InviteCodeNavigateAction> get() = _navigateAction.asSharedFlow()
@@ -54,7 +54,7 @@ class InviteCodeViewModel
                     .suspendOnSuccess {
                         _navigateAction.emit(InviteCodeNavigateAction.CodeNavigateToJoin)
                     }.suspendOnFailure { code, errorMessage ->
-                        _invitationCodeEvent.emit(errorMessage.toString())
+                        _invalidCodeEvent.emit(errorMessage.toString())
                         analyticsHelper.logNetworkErrorEvent(TAG, "$code $errorMessage")
                     }.onNetworkError {
                         handleNetworkError()

--- a/android/app/src/test/java/com/mulberry/ody/presentation/invitecode/InviteCodeViewModelTest.kt
+++ b/android/app/src/test/java/com/mulberry/ody/presentation/invitecode/InviteCodeViewModelTest.kt
@@ -54,7 +54,7 @@ class InviteCodeViewModelTest {
 
             // when
             val actual =
-                viewModel.invitationCodeEvent.valueOnAction {
+                viewModel.invalidCodeEvent.valueOnAction {
                     viewModel.checkInviteCode()
                 }
 

--- a/android/app/src/test/java/com/mulberry/ody/presentation/invitecode/InviteCodeViewModelTest.kt
+++ b/android/app/src/test/java/com/mulberry/ody/presentation/invitecode/InviteCodeViewModelTest.kt
@@ -54,12 +54,12 @@ class InviteCodeViewModelTest {
 
             // when
             val actual =
-                viewModel.invalidInviteCodeEvent.valueOnAction {
+                viewModel.invitationCodeEvent.valueOnAction {
                     viewModel.checkInviteCode()
                 }
 
             // then
-            assertThat(actual).isInstanceOf(Unit::class.java)
+            assertThat(actual).isInstanceOf(String::class.java)
         }
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #893 


<br>

# 📝 작업 내용
- [x] 초대코드 유효하지 않은 메시지 서버로부터 받게 변경

<br>

# 🏞️ 스크린샷 (선택)
1. 이상한 코드 입력 시

<img src="https://github.com/user-attachments/assets/6907038b-e985-492e-80c7-cc95946c78e2"  width="30%" height="60%"/>

2. 이미 참여한 방 참여 시

<img src="https://github.com/user-attachments/assets/4177dbee-9107-42f5-b5cb-45755518cd1a"  width="30%" height="60%"/>

3. 과거 약속 참여 시

옛날 초대 코드 입력하고 싶은데 있으신 분..

<br>

# 🗣️ 리뷰 요구사항 (선택)
