### PR TITLE
fix: 재촉을 못할때는 재촉 요청이 안가게 수정

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/presentation/room/MeetingRoomViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/room/MeetingRoomViewModel.kt
@@ -146,7 +146,7 @@ class MeetingRoomViewModel
         ) {
             meetingRepository.postNudge(Nudge(nudgeId, mateId))
                 .suspendOnSuccess {
-                        _nudgeSuccessMate.emit(mateNickname)
+                    _nudgeSuccessMate.emit(mateNickname)
                 }.suspendOnFailure { code, errorMessage ->
                     when (code) {
                         400 -> _expiredNudgeTimeLimit.emit(Unit)


### PR DESCRIPTION
# 🚩 연관 이슈 
close #853 


<br>

# 📝 작업 내용
- [x] 재촉을 못할때는 재촉 요청이 안가게 수정

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
잘되는거 확인했습니다! 
동일한 에뮬레이터에서 앱을 실행한뒤 방 생성(오디냥 계정으로) -> 어플 삭제 -> 어플재설치 -> 방 참여(해음 계정으로)
왜 인지는 모르겠지만 실기기와 에뮬레이터로 하니 잘 되네요!