### PR TITLE
chore: Redis 연결 설정 오류 해결

### DIFF
--- a/backend/src/main/java/com/ody/common/config/RedisConfig.java
+++ b/backend/src/main/java/com/ody/common/config/RedisConfig.java
@@ -1,6 +1,7 @@
 package com.ody.common.config;
 
 import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -10,7 +11,6 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -22,18 +22,18 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableCaching
 public class RedisConfig {
 
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
-                .commandTimeout(Duration.ofSeconds(3))
-                .build();
-
-        return new LettuceConnectionFactory(redisStandaloneConfiguration(), clientConfig);
-    }
-
-    @Bean
-    public RedisStandaloneConfiguration redisStandaloneConfiguration() {
-        return new RedisStandaloneConfiguration();
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(host);
+        configuration.setPort(port);
+        return new LettuceConnectionFactory(configuration);
     }
 
     @Bean

--- a/backend/src/main/resources/common.yml
+++ b/backend/src/main/resources/common.yml
@@ -5,6 +5,7 @@ spring:
   data:
     redis:
       port: 6379
+      connect-timeout: 3000
   jpa:
     open-in-view: false
     defer-datasource-initialization: false


### PR DESCRIPTION
# 🚩 연관 이슈 
close #917 

<br>

# 📝 작업 내용

미션에서 설정할 때는 LettuceConnectionFactory를 파라미터 없이 생성하면
기본적으로 프로퍼티의 설정을 읽어 세팅되어 몰랐는데

redisStandaloneConfiguration은 host와 port를 설정해주지않으면 기본적으로 localhost로 등록이 되버리네요..
따라서 호스트와 포트를 지정해주었습니다

```
    @Bean
    public RedisConnectionFactory redisConnectionFactory() {
        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
        configuration.setHostName(host);
        configuration.setPort(port);
        return new LettuceConnectionFactory(configuration);
    }

```


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
