### PR TITLE
feat: 주소 검색 무한 스크롤 구현

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -34,7 +34,7 @@ android {
         buildConfigField(
             "String",
             "PRIVACY_POLICY_URI",
-            properties["PRIVACY_POLICY_URI"].toString()
+            properties["PRIVACY_POLICY_URI"].toString(),
         )
         buildConfigField("String", "TERM_URI", properties["TERM_URI"].toString())
         manifestPlaceholders["KAKAO_NATIVE_KEY"] =

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -135,8 +135,8 @@ dependencies {
     // timber
     implementation(libs.timber)
 
-    // dotsibdicator
-    implementation(libs.dotsinbdicator)
+    // dotsindicator
+    implementation(libs.dotsindicator)
 
     // play service
     implementation(libs.play.services.location)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -31,9 +31,14 @@ android {
         buildConfigField("String", "BASE_PROD_URL", properties["BASE_PROD_URL"].toString())
         buildConfigField("String", "KAKAO_API_KEY", properties["KAKAO_API_KEY"].toString())
         buildConfigField("String", "KAKAO_NATIVE_KEY", properties["KAKAO_NATIVE_KEY"].toString())
-        buildConfigField("String", "PRIVACY_POLICY_URI", properties["PRIVACY_POLICY_URI"].toString())
+        buildConfigField(
+            "String",
+            "PRIVACY_POLICY_URI",
+            properties["PRIVACY_POLICY_URI"].toString()
+        )
         buildConfigField("String", "TERM_URI", properties["TERM_URI"].toString())
-        manifestPlaceholders["KAKAO_NATIVE_KEY"] = properties["KAKAO_NATIVE_KEY"].toString().trim('"')
+        manifestPlaceholders["KAKAO_NATIVE_KEY"] =
+            properties["KAKAO_NATIVE_KEY"].toString().trim('"')
     }
     buildTypes {
         debug {
@@ -131,7 +136,7 @@ dependencies {
     implementation(libs.timber)
 
     // dotsibdicator
-    implementation(libs.dotsibdicator)
+    implementation(libs.dotsinbdicator)
 
     // play service
     implementation(libs.play.services.location)
@@ -152,4 +157,7 @@ dependencies {
     // hilt
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
+
+    // paging
+    implementation(libs.androidx.paging)
 }

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/AddressPagingSource.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/AddressPagingSource.kt
@@ -13,11 +13,12 @@ class AddressPagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Address> {
         val page = params.key ?: 1
         return runCatching {
-            val address = addressRepository.fetchAddresses(
-                keyword = keyword,
-                page = page,
-                pageSize = PAGE_SIZE,
-            ).getOrThrow()
+            val address =
+                addressRepository.fetchAddresses(
+                    keyword = keyword,
+                    page = page,
+                    pageSize = PAGE_SIZE,
+                ).getOrThrow()
 
             val prevKey = if (page == 1) null else page - PAGE_OFFSET
             val nextKey = if (address.isEnd) null else page + PAGE_OFFSET

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/AddressPagingSource.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/AddressPagingSource.kt
@@ -1,0 +1,45 @@
+package com.mulberry.ody.data.remote.thirdparty.address
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.mulberry.ody.domain.apiresult.getOrThrow
+import com.mulberry.ody.domain.model.Address
+import com.mulberry.ody.domain.repository.location.AddressRepository
+
+class AddressPagingSource(
+    private val keyword: String,
+    private val addressRepository: AddressRepository,
+) : PagingSource<Int, Address>() {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Address> {
+        val page = params.key ?: 1
+        return runCatching {
+            val address = addressRepository.fetchAddresses(
+                keyword = keyword,
+                page = page,
+                pageSize = PAGE_SIZE,
+            ).getOrThrow()
+
+            val prevKey = if (page == 1) null else page - PAGE_OFFSET
+            val nextKey = if (address.isEnd) null else page + PAGE_OFFSET
+
+            LoadResult.Page(
+                data = address.addresses,
+                prevKey = prevKey,
+                nextKey = nextKey,
+            )
+        }.getOrElse { throwable ->
+            LoadResult.Error(throwable)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Address>): Int? {
+        val anchorPosition = state.anchorPosition ?: return null
+        val anchorPage = state.closestPageToPosition(anchorPosition) ?: return null
+        return anchorPage.prevKey?.plus(PAGE_OFFSET) ?: anchorPage.nextKey?.minus(PAGE_OFFSET)
+    }
+
+    companion object {
+        private const val PAGE_OFFSET = 1
+        private const val PAGE_SIZE = 10
+    }
+}

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/AddressPagingSource.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/AddressPagingSource.kt
@@ -11,20 +11,20 @@ class AddressPagingSource(
     private val addressRepository: AddressRepository,
 ) : PagingSource<Int, Address>() {
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Address> {
-        val page = params.key ?: 1
+        val page = params.key ?: PAGE_START
         return runCatching {
-            val address =
+            val addresses =
                 addressRepository.fetchAddresses(
                     keyword = keyword,
                     page = page,
                     pageSize = PAGE_SIZE,
                 ).getOrThrow()
 
-            val prevKey = if (page == 1) null else page - PAGE_OFFSET
-            val nextKey = if (address.isEnd) null else page + PAGE_OFFSET
+            val prevKey = if (page == PAGE_START) null else page - PAGE_OFFSET
+            val nextKey = if (addresses.isEnd) null else page + PAGE_OFFSET
 
             LoadResult.Page(
-                data = address.addresses,
+                data = addresses.addresses,
                 prevKey = prevKey,
                 nextKey = nextKey,
             )
@@ -40,7 +40,8 @@ class AddressPagingSource(
     }
 
     companion object {
+        private const val PAGE_START = 1
         private const val PAGE_OFFSET = 1
-        private const val PAGE_SIZE = 10
+        const val PAGE_SIZE = 10
     }
 }

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/KakaoAddressRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/KakaoAddressRepository.kt
@@ -3,7 +3,7 @@ package com.mulberry.ody.data.remote.thirdparty.address
 import com.mulberry.ody.data.remote.thirdparty.address.response.toAddresses
 import com.mulberry.ody.domain.apiresult.ApiResult
 import com.mulberry.ody.domain.apiresult.map
-import com.mulberry.ody.domain.model.Address
+import com.mulberry.ody.domain.model.Addresses
 import com.mulberry.ody.domain.repository.location.AddressRepository
 import javax.inject.Inject
 
@@ -12,8 +12,9 @@ class KakaoAddressRepository
     constructor(private val service: KakaoAddressService) : AddressRepository {
         override suspend fun fetchAddresses(
             keyword: String,
+            page:Int,
             pageSize: Int,
-        ): ApiResult<List<Address>> {
+        ): ApiResult<Addresses> {
             return service.fetchAddresses(keyword, pageSize).map { it.toAddresses() }
         }
 

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/KakaoAddressRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/KakaoAddressRepository.kt
@@ -12,7 +12,7 @@ class KakaoAddressRepository
     constructor(private val service: KakaoAddressService) : AddressRepository {
         override suspend fun fetchAddresses(
             keyword: String,
-            page:Int,
+            page: Int,
             pageSize: Int,
         ): ApiResult<Addresses> {
             return service.fetchAddresses(keyword, pageSize).map { it.toAddresses() }

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/KakaoAddressRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/KakaoAddressRepository.kt
@@ -15,7 +15,7 @@ class KakaoAddressRepository
             page: Int,
             pageSize: Int,
         ): ApiResult<Addresses> {
-            return service.fetchAddresses(keyword, pageSize).map { it.toAddresses() }
+            return service.fetchAddresses(keyword, page, pageSize).map { it.toAddresses() }
         }
 
         override suspend fun fetchAddressesByCoordinate(

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/KakaoAddressService.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/KakaoAddressService.kt
@@ -10,7 +10,8 @@ interface KakaoAddressService {
     @GET("/v2/local/search/keyword.json")
     suspend fun fetchAddresses(
         @Query("query") keyword: String,
-        @Query("size") size: Int,
+        @Query("page") page: Int,
+        @Query("size") pageSize: Int,
     ): ApiResult<AddressResponse>
 
     @GET("/v2/local/geo/coord2address.json")

--- a/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/response/AddressResponseMapper.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/remote/thirdparty/address/response/AddressResponseMapper.kt
@@ -1,9 +1,11 @@
 package com.mulberry.ody.data.remote.thirdparty.address.response
 
 import com.mulberry.ody.domain.model.Address
+import com.mulberry.ody.domain.model.Addresses
 
-fun AddressResponse.toAddresses(): List<Address> {
-    return documents.map { it.toAddress() }
+fun AddressResponse.toAddresses(): Addresses {
+    val addresses = documents.map { it.toAddress() }
+    return Addresses(addresses, meta.isEnd)
 }
 
 private fun Document.toAddress(): Address {

--- a/android/app/src/main/java/com/mulberry/ody/domain/apiresult/ApiResultExtensions.kt
+++ b/android/app/src/main/java/com/mulberry/ody/domain/apiresult/ApiResultExtensions.kt
@@ -1,5 +1,7 @@
 package com.mulberry.ody.domain.apiresult
 
+import java.lang.IllegalArgumentException
+
 fun <T> ApiResult<T>.onSuccess(block: (T) -> Unit): ApiResult<T> {
     if (this is ApiResult.Success) {
         block(this.data)
@@ -67,6 +69,15 @@ suspend fun <T, R> ApiResult<T>.map(block: suspend (T) -> R): ApiResult<R> {
 
 fun <T> ApiResult<T>.getOrNull(): T? {
     return if (this is ApiResult.Success) data else null
+}
+
+fun <T> ApiResult<T>.getOrThrow(): T {
+    when (this) {
+        is ApiResult.Failure -> throw IllegalArgumentException(errorMessage)
+        is ApiResult.NetworkError -> throw exception
+        is ApiResult.Unexpected -> throw t
+        is ApiResult.Success -> return data
+    }
 }
 
 fun <T> Result<T>.toApiResult(): ApiResult<T> {

--- a/android/app/src/main/java/com/mulberry/ody/domain/model/Addresses.kt
+++ b/android/app/src/main/java/com/mulberry/ody/domain/model/Addresses.kt
@@ -1,0 +1,6 @@
+package com.mulberry.ody.domain.model
+
+class Addresses(
+    val addresses: List<Address>,
+    val isEnd: Boolean,
+)

--- a/android/app/src/main/java/com/mulberry/ody/domain/repository/location/AddressRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/domain/repository/location/AddressRepository.kt
@@ -1,7 +1,6 @@
 package com.mulberry.ody.domain.repository.location
 
 import com.mulberry.ody.domain.apiresult.ApiResult
-import com.mulberry.ody.domain.model.Address
 import com.mulberry.ody.domain.model.Addresses
 
 interface AddressRepository {

--- a/android/app/src/main/java/com/mulberry/ody/domain/repository/location/AddressRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/domain/repository/location/AddressRepository.kt
@@ -2,12 +2,14 @@ package com.mulberry.ody.domain.repository.location
 
 import com.mulberry.ody.domain.apiresult.ApiResult
 import com.mulberry.ody.domain.model.Address
+import com.mulberry.ody.domain.model.Addresses
 
 interface AddressRepository {
     suspend fun fetchAddresses(
         keyword: String,
+        page: Int,
         pageSize: Int,
-    ): ApiResult<List<Address>>
+    ): ApiResult<Addresses>
 
     suspend fun fetchAddressesByCoordinate(
         x: String,

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
@@ -59,6 +59,9 @@ class AddressSearchFragment :
             }
         binding.rvAddress.addItemDecoration(dividerItemDecoration)
         binding.rvAddress.adapter = adapter
+        adapter.addLoadStateListener {
+            viewModel.emptyAddresses(adapter.itemCount == 0)
+        }
     }
 
     private fun initializeBinding() {
@@ -81,9 +84,6 @@ class AddressSearchFragment :
         collectWhenStarted(viewModel.networkErrorEvent) {
             showRetrySnackBar { viewModel.retryLastAction() }
         }
-        collectWhenStarted(viewModel.addressUiModels) {
-            adapter.submitList(it)
-        }
         collectWhenStarted(viewModel.addressSelectEvent) {
             (parentFragment as? AddressSearchListener)?.onReceive(it)
             (activity as? AddressSearchListener)?.onReceive(it)
@@ -91,6 +91,9 @@ class AddressSearchFragment :
         }
         collectWhenStarted(viewModel.addressSearchKeyword) {
             if (it.isEmpty()) viewModel.clearAddresses()
+        }
+        collectWhenStarted(viewModel.addressClearEvent) {
+            adapter.refresh()
         }
     }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
@@ -89,12 +89,13 @@ class AddressSearchFragment :
             (activity as? AddressSearchListener)?.onReceive(it)
             onBack()
         }
-        collectWhenStarted(viewModel.addressSearchKeyword) {
-            if (it.isEmpty()) viewModel.clearAddresses()
+        collectWhenStarted(viewModel.hasAddressSearchKeyword) { hasKeyword ->
+            if (hasKeyword) {
+                return@collectWhenStarted
+            }
+            viewModel.clearAddresses()
         }
-        collectWhenStarted(viewModel.addressClearEvent) {
-            adapter.refresh()
-        }
+
         collectWhenStarted(viewModel.address) {
             adapter.submitData(viewLifecycleOwner.lifecycle, it)
         }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
@@ -60,7 +60,7 @@ class AddressSearchFragment :
         binding.rvAddress.addItemDecoration(dividerItemDecoration)
         binding.rvAddress.adapter = adapter
         adapter.addLoadStateListener {
-            viewModel.emptyAddresses(adapter.itemCount == 0)
+            viewModel.updateAddressItemCount(adapter.itemCount)
         }
     }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchFragment.kt
@@ -95,6 +95,9 @@ class AddressSearchFragment :
         collectWhenStarted(viewModel.addressClearEvent) {
             adapter.refresh()
         }
+        collectWhenStarted(viewModel.address) {
+            adapter.submitData(viewLifecycleOwner.lifecycle, it)
+        }
     }
 
     override fun onBack() {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
@@ -47,18 +47,18 @@ class AddressSearchViewModel
         private val _addressSelectEvent: MutableSharedFlow<Address> = MutableSharedFlow()
         val addressSelectEvent: SharedFlow<Address> get() = _addressSelectEvent.asSharedFlow()
 
-        private val _addressClearEvent: MutableSharedFlow<Unit> = MutableSharedFlow()
-        val addressClearEvent: SharedFlow<Unit> get() = _addressClearEvent.asSharedFlow()
-
         fun clearAddressSearchKeyword() {
             addressSearchKeyword.value = ""
         }
 
         fun searchAddress() {
             val addressSearchKeyword = addressSearchKeyword.value
-            if (addressSearchKeyword.isEmpty()) return
 
             viewModelScope.launch {
+                if (addressSearchKeyword.isBlank()) {
+                    clearAddresses()
+                }
+
                 startLoading()
                 Pager(
                     config = PagingConfig(pageSize = PAGE_SIZE),
@@ -73,7 +73,7 @@ class AddressSearchViewModel
                     .collectLatest {
                         _address.emit(it)
                         stopLoading()
-                }
+                    }
             }
         }
 
@@ -91,7 +91,8 @@ class AddressSearchViewModel
 
         fun clearAddresses() {
             viewModelScope.launch {
-                _addressClearEvent.emit(Unit)
+                _address.emit(PagingData.empty())
+                _isEmptyAddresses.emit(true)
             }
         }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
@@ -6,6 +6,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.mulberry.ody.data.remote.thirdparty.address.AddressPagingSource
+import com.mulberry.ody.data.remote.thirdparty.address.AddressPagingSource.Companion.PAGE_SIZE
 import com.mulberry.ody.domain.model.Address
 import com.mulberry.ody.domain.repository.location.AddressRepository
 import com.mulberry.ody.presentation.address.listener.AddressListener
@@ -95,7 +96,6 @@ class AddressSearchViewModel
         }
 
         companion object {
-            private const val PAGE_SIZE = 10
             private const val STATE_FLOW_SUBSCRIPTION_TIMEOUT_MILLIS = 5000L
         }
     }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
@@ -13,7 +13,6 @@ import com.mulberry.ody.presentation.address.listener.AddressListener
 import com.mulberry.ody.presentation.address.model.AddressUiModel
 import com.mulberry.ody.presentation.address.model.toAddressUiModel
 import com.mulberry.ody.presentation.common.BaseViewModel
-import com.mulberry.ody.presentation.common.analytics.AnalyticsHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,7 +30,6 @@ import javax.inject.Inject
 class AddressSearchViewModel
     @Inject
     constructor(
-        private val analyticsHelper: AnalyticsHelper,
         private val addressRepository: AddressRepository,
     ) : BaseViewModel(), AddressListener {
         val addressSearchKeyword: MutableStateFlow<String> = MutableStateFlow("")
@@ -45,7 +43,8 @@ class AddressSearchViewModel
         private val _address: MutableStateFlow<PagingData<AddressUiModel>> = MutableStateFlow(PagingData.empty())
         val address: StateFlow<PagingData<AddressUiModel>> get() = _address
 
-        private val isEmptyAddresses: MutableStateFlow<Boolean> = MutableStateFlow(true)
+        private val _isEmptyAddresses: MutableStateFlow<Boolean> = MutableStateFlow(true)
+        val isEmptyAddresses: StateFlow<Boolean> get() = _isEmptyAddresses
 
         private val _addressSelectEvent: MutableSharedFlow<Address> = MutableSharedFlow()
         val addressSelectEvent: SharedFlow<Address> get() = _addressSelectEvent.asSharedFlow()
@@ -85,9 +84,9 @@ class AddressSearchViewModel
             }
         }
 
-        fun emptyAddresses(isEmpty: Boolean) {
+        fun updateAddressItemCount(itemCount: Int) {
             viewModelScope.launch {
-                isEmptyAddresses.emit(isEmpty)
+                _isEmptyAddresses.emit(itemCount == 0)
             }
         }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
@@ -5,13 +5,10 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
-import androidx.paging.map
 import com.mulberry.ody.data.remote.thirdparty.address.AddressPagingSource
 import com.mulberry.ody.domain.model.Address
 import com.mulberry.ody.domain.repository.location.AddressRepository
 import com.mulberry.ody.presentation.address.listener.AddressListener
-import com.mulberry.ody.presentation.address.model.AddressUiModel
-import com.mulberry.ody.presentation.address.model.toAddressUiModel
 import com.mulberry.ody.presentation.common.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -40,8 +37,8 @@ class AddressSearchViewModel
                 initialValue = false,
             )
 
-        private val _address: MutableStateFlow<PagingData<AddressUiModel>> = MutableStateFlow(PagingData.empty())
-        val address: StateFlow<PagingData<AddressUiModel>> get() = _address
+        private val _address: MutableStateFlow<PagingData<Address>> = MutableStateFlow(PagingData.empty())
+        val address: StateFlow<PagingData<Address>> get() = _address
 
         private val _isEmptyAddresses: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val isEmptyAddresses: StateFlow<Boolean> get() = _isEmptyAddresses
@@ -70,10 +67,9 @@ class AddressSearchViewModel
                             addressRepository = addressRepository,
                         )
                     },
-                ).flow.cachedIn(viewModelScope)
-                    .collectLatest { pagingData ->
-                        _address.emit(pagingData.map { it.toAddressUiModel() })
-                    }
+                ).flow
+                    .cachedIn(viewModelScope)
+                    .collectLatest { _address.emit(it) }
                 stopLoading()
             }
         }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/AddressSearchViewModel.kt
@@ -69,8 +69,10 @@ class AddressSearchViewModel
                     },
                 ).flow
                     .cachedIn(viewModelScope)
-                    .collectLatest { _address.emit(it) }
-                stopLoading()
+                    .collectLatest {
+                        _address.emit(it)
+                        stopLoading()
+                }
             }
         }
 

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/adapter/AddressesAdapter.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/adapter/AddressesAdapter.kt
@@ -5,13 +5,13 @@ import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import com.mulberry.ody.databinding.ItemAddressSearchBinding
+import com.mulberry.ody.domain.model.Address
 import com.mulberry.ody.presentation.address.listener.AddressListener
 import com.mulberry.ody.presentation.address.listener.AddressViewHolder
-import com.mulberry.ody.presentation.address.model.AddressUiModel
 
 class AddressesAdapter(
     private val addressListener: AddressListener,
-) : PagingDataAdapter<AddressUiModel, AddressViewHolder>(diffUtil) {
+) : PagingDataAdapter<Address, AddressViewHolder>(diffUtil) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
@@ -30,15 +30,15 @@ class AddressesAdapter(
 
     companion object {
         private val diffUtil =
-            object : DiffUtil.ItemCallback<AddressUiModel>() {
+            object : DiffUtil.ItemCallback<Address>() {
                 override fun areItemsTheSame(
-                    oldItem: AddressUiModel,
-                    newItem: AddressUiModel,
+                    oldItem: Address,
+                    newItem: Address,
                 ): Boolean = oldItem == newItem
 
                 override fun areContentsTheSame(
-                    oldItem: AddressUiModel,
-                    newItem: AddressUiModel,
+                    oldItem: Address,
+                    newItem: Address,
                 ): Boolean = oldItem == newItem
             }
     }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/adapter/AddressesAdapter.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/adapter/AddressesAdapter.kt
@@ -39,7 +39,7 @@ class AddressesAdapter(
                 override fun areContentsTheSame(
                     oldItem: Address,
                     newItem: Address,
-                ): Boolean = oldItem == newItem
+                ): Boolean = oldItem.id == newItem.id
             }
     }
 }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/adapter/AddressesAdapter.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/adapter/AddressesAdapter.kt
@@ -2,8 +2,8 @@ package com.mulberry.ody.presentation.address.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import com.mulberry.ody.databinding.ItemAddressSearchBinding
 import com.mulberry.ody.presentation.address.listener.AddressListener
 import com.mulberry.ody.presentation.address.listener.AddressViewHolder
@@ -11,7 +11,7 @@ import com.mulberry.ody.presentation.address.model.AddressUiModel
 
 class AddressesAdapter(
     private val addressListener: AddressListener,
-) : ListAdapter<AddressUiModel, AddressViewHolder>(diffUtil) {
+) : PagingDataAdapter<AddressUiModel, AddressViewHolder>(diffUtil) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
@@ -24,7 +24,8 @@ class AddressesAdapter(
         holder: AddressViewHolder,
         position: Int,
     ) {
-        holder.bind(getItem(position), addressListener)
+        val address = getItem(position) ?: return
+        holder.bind(address, addressListener)
     }
 
     companion object {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/listener/AddressListener.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/listener/AddressListener.kt
@@ -1,5 +1,7 @@
 package com.mulberry.ody.presentation.address.listener
 
+import com.mulberry.ody.domain.model.Address
+
 interface AddressListener {
-    fun onClickAddressItem(id: Long)
+    fun onClickAddressItem(address: Address)
 }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/listener/AddressViewHolder.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/listener/AddressViewHolder.kt
@@ -2,15 +2,15 @@ package com.mulberry.ody.presentation.address.listener
 
 import androidx.recyclerview.widget.RecyclerView
 import com.mulberry.ody.databinding.ItemAddressSearchBinding
-import com.mulberry.ody.presentation.address.model.AddressUiModel
+import com.mulberry.ody.domain.model.Address
 
 class AddressViewHolder(private val binding: ItemAddressSearchBinding) :
     RecyclerView.ViewHolder(binding.root) {
     fun bind(
-        addressUiModel: AddressUiModel,
+        address: Address,
         addressListener: AddressListener,
     ) {
-        binding.address = addressUiModel
+        binding.address = address
         binding.addressListener = addressListener
     }
 }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/model/AddressUiModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/model/AddressUiModel.kt
@@ -1,7 +1,0 @@
-package com.mulberry.ody.presentation.address.model
-
-data class AddressUiModel(
-    val id: Long,
-    val placeName: String = "",
-    val detailAddress: String,
-)

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/model/AddressUiModelMapper.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/model/AddressUiModelMapper.kt
@@ -2,6 +2,4 @@ package com.mulberry.ody.presentation.address.model
 
 import com.mulberry.ody.domain.model.Address
 
-fun List<Address>.toAddressUiModels(): List<AddressUiModel> = map { it.toAddressUiModel() }
-
-private fun Address.toAddressUiModel(): AddressUiModel = AddressUiModel(id = id, placeName = placeName, detailAddress = detailAddress)
+fun Address.toAddressUiModel(): AddressUiModel = AddressUiModel(id = id, placeName = placeName, detailAddress = detailAddress)

--- a/android/app/src/main/java/com/mulberry/ody/presentation/address/model/AddressUiModelMapper.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/address/model/AddressUiModelMapper.kt
@@ -1,5 +1,0 @@
-package com.mulberry.ody.presentation.address.model
-
-import com.mulberry.ody.domain.model.Address
-
-fun Address.toAddressUiModel(): AddressUiModel = AddressUiModel(id = id, placeName = placeName, detailAddress = detailAddress)

--- a/android/app/src/main/res/layout/item_address_search.xml
+++ b/android/app/src/main/res/layout/item_address_search.xml
@@ -7,7 +7,7 @@
 
         <variable
             name="address"
-            type="com.mulberry.ody.presentation.address.model.AddressUiModel" />
+            type="com.mulberry.ody.domain.model.Address" />
 
         <variable
             name="addressListener"

--- a/android/app/src/main/res/layout/item_address_search.xml
+++ b/android/app/src/main/res/layout/item_address_search.xml
@@ -19,7 +19,7 @@
         android:layout_height="wrap_content"
         android:background="@color/primary"
         android:paddingVertical="18dp"
-        app:onSingleClick="@{() -> addressListener.onClickAddressItem(address.id)}">
+        app:onSingleClick="@{() -> addressListener.onClickAddressItem(address)}">
 
         <ImageView
             android:id="@+id/iv_address_search_location"

--- a/android/app/src/test/java/com/mulberry/ody/TestFixtures.kt
+++ b/android/app/src/test/java/com/mulberry/ody/TestFixtures.kt
@@ -1,6 +1,7 @@
 package com.mulberry.ody
 
 import com.mulberry.ody.domain.model.Address
+import com.mulberry.ody.domain.model.Addresses
 import com.mulberry.ody.domain.model.EtaStatus
 import com.mulberry.ody.domain.model.Mate
 import com.mulberry.ody.domain.model.MateEta
@@ -123,4 +124,10 @@ fun Address(
     return Address(id = id, detailAddress = roadNameAddress, placeName = "", latitude = "0.0", longitude = "0.0")
 }
 
-val addresses: List<Address> = List(5) { Address(id = it.toLong(), roadNameAddress = "") }
+val address = Address(id = 0L, roadNameAddress = "")
+
+val addresses: Addresses =
+    Addresses(
+        addresses = List(5) { Address(id = it.toLong(), roadNameAddress = "") },
+        isEnd = true,
+    )

--- a/android/app/src/test/java/com/mulberry/ody/fake/FakeAddressRepository.kt
+++ b/android/app/src/test/java/com/mulberry/ody/fake/FakeAddressRepository.kt
@@ -2,7 +2,7 @@ package com.mulberry.ody.fake
 
 import com.mulberry.ody.addresses
 import com.mulberry.ody.domain.apiresult.ApiResult
-import com.mulberry.ody.domain.model.Address
+import com.mulberry.ody.domain.model.Addresses
 import com.mulberry.ody.domain.repository.location.AddressRepository
 
 object FakeAddressRepository : AddressRepository {
@@ -10,7 +10,7 @@ object FakeAddressRepository : AddressRepository {
         keyword: String,
         page: Int,
         pageSize: Int,
-    ): ApiResult<List<Address>> {
+    ): ApiResult<Addresses> {
         return ApiResult.Success(addresses)
     }
 

--- a/android/app/src/test/java/com/mulberry/ody/fake/FakeAddressRepository.kt
+++ b/android/app/src/test/java/com/mulberry/ody/fake/FakeAddressRepository.kt
@@ -8,6 +8,7 @@ import com.mulberry.ody.domain.repository.location.AddressRepository
 object FakeAddressRepository : AddressRepository {
     override suspend fun fetchAddresses(
         keyword: String,
+        page: Int,
         pageSize: Int,
     ): ApiResult<List<Address>> {
         return ApiResult.Success(addresses)

--- a/android/app/src/test/java/com/mulberry/ody/presentation/address/AddressSearchViewModelTest.kt
+++ b/android/app/src/test/java/com/mulberry/ody/presentation/address/AddressSearchViewModelTest.kt
@@ -1,13 +1,12 @@
 package com.mulberry.ody.presentation.address
 
-import com.mulberry.ody.addresses
+import androidx.paging.map
+import com.mulberry.ody.address
 import com.mulberry.ody.fake.FakeAddressRepository
 import com.mulberry.ody.fake.FakeAnalyticsHelper
-import com.mulberry.ody.presentation.address.model.toAddressUiModels
 import com.mulberry.ody.util.CoroutinesTestExtension
 import com.mulberry.ody.util.InstantTaskExecutorExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -39,8 +38,9 @@ class AddressSearchViewModelTest {
             viewModel.searchAddress()
 
             // then
-            val actual = viewModel.addressUiModels.first()
-            assertThat(actual).isEqualTo(addresses.toAddressUiModels())
+            viewModel.address.value.map { actual ->
+                assertThat(actual).isEqualTo(address)
+            }
         }
     }
 }

--- a/android/app/src/test/java/com/mulberry/ody/presentation/address/AddressSearchViewModelTest.kt
+++ b/android/app/src/test/java/com/mulberry/ody/presentation/address/AddressSearchViewModelTest.kt
@@ -22,10 +22,7 @@ class AddressSearchViewModelTest {
     @BeforeEach
     fun setUp() {
         viewModel =
-            AddressSearchViewModel(
-                analyticsHelper = FakeAnalyticsHelper,
-                addressRepository = FakeAddressRepository,
-            )
+            AddressSearchViewModel(addressRepository = FakeAddressRepository)
     }
 
     @Test

--- a/android/app/src/test/java/com/mulberry/ody/presentation/address/AddressSearchViewModelTest.kt
+++ b/android/app/src/test/java/com/mulberry/ody/presentation/address/AddressSearchViewModelTest.kt
@@ -3,7 +3,6 @@ package com.mulberry.ody.presentation.address
 import androidx.paging.map
 import com.mulberry.ody.address
 import com.mulberry.ody.fake.FakeAddressRepository
-import com.mulberry.ody.fake.FakeAnalyticsHelper
 import com.mulberry.ody.util.CoroutinesTestExtension
 import com.mulberry.ody.util.InstantTaskExecutorExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -99,7 +99,7 @@ moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", ver
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 
 # dotsindicator
-dotsinbdicator = { group = "com.tbuonomo", name = "dotsindicator", version.ref = "dotsindicator" }
+dotsindicator = { group = "com.tbuonomo", name = "dotsindicator", version.ref = "dotsindicator" }
 
 # loggig
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "loggingInterceptor" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 activity = "1.9.2"
 agp = "8.5.0"
 androidJunitJupiter = "1.10.0.0"
+androidxPaging = "3.3.4"
 appcompat = "1.7.0"
 assertj = "3.25.3"
 constraintlayout = "2.1.4"
@@ -43,7 +44,6 @@ splashScreen = "1.0.1"
 timber = "5.0.1"
 viewPager = "1.1.0"
 workRuntimeKtx = "2.9.1"
-androidxPaging = "3.3.4"
 
 [libraries]
 # androidx

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ fragmentKtx = "1.8.3"
 fragmentTesting = "1.8.3"
 glide = "4.16.0"
 googleServices = "4.4.2"
-hilt= "2.52"
+hilt = "2.52"
 hiltWork = "1.2.0"
 junitJupiter = "5.10.2"
 junitVersion = "1.2.1"
@@ -43,6 +43,7 @@ splashScreen = "1.0.1"
 timber = "5.0.1"
 viewPager = "1.1.0"
 workRuntimeKtx = "2.9.1"
+androidxPaging = "3.3.4"
 
 [libraries]
 # androidx
@@ -63,10 +64,9 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodel" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 androidx-datastore-core-android = { group = "androidx.datastore", name = "datastore-core-android", version.ref = "datastoreCoreAndroid" }
-androidx-room-runtime = {group ="androidx.room", name = "room-runtime", version.ref = "room"}
-androidx-room-compiler = {group ="androidx.room", name = "room-compiler", version.ref = "room"}
-androidx-room-ktx = {group ="androidx.room", name = "room-ktx", version.ref = "room"}
-
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 
 # junit
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }
@@ -99,7 +99,7 @@ moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", ver
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 
 # dotsindicator
-dotsibdicator = { group = "com.tbuonomo", name = "dotsindicator", version.ref = "dotsindicator" }
+dotsinbdicator = { group = "com.tbuonomo", name = "dotsindicator", version.ref = "dotsindicator" }
 
 # loggig
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "loggingInterceptor" }
@@ -112,7 +112,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 
 # kakao sdk
-kakao-sdk-v2-user = {module = "com.kakao.sdk:v2-user", version.ref = "kakaoSdk"}
+kakao-sdk-v2-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoSdk" }
 
 # glide
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
@@ -123,6 +123,9 @@ kakao-share = { module = "com.kakao.sdk:v2-share", version.ref = "kakaoShare" }
 # hilt
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
+
+# paging
+androidx-paging = { group = "androidx.paging", name = "paging-runtime", version.ref = "androidxPaging" }
 
 [plugins]
 jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jvm" }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #677


<br>

# 📝 작업 내용
- [x] 주소 검색 무한 스크롤

<br>

# 🏞️ 스크린샷 (선택)

https://github.com/user-attachments/assets/46082fbd-ad12-415d-8f14-78bfe1ec8de5


영상에는 한번에 로드하는 것 같아보이지만 ㅎㅎ 로그 찍어보니 지연 로딩 잘 되었습니다

<br>

# 🗣️ 리뷰 요구사항 (선택)
학습 + 구현 부담 감소를 위해 paging3 라이브러리를 사용해봤어요 
언제 다음 페이지를 로드할지를 신경쓰지 않아도 되니 편하네요!

무한 스크롤을 위해 핵심이 되는 코드는 `AddressPagingSource`입니다
paging3 내부적으로 다음 페이지를 로드할 시점이 되면 `AddressPagingSource`의 `load()` 함수를 호출한다고 합니다
구체적인 라이브러리 사용 방법은 구글에 서치만 해도 많이 나와있어서, 전체적인 흐름을 요약해보았어요~
```
1. data단의 AddressPagingSource에서 페이지 load
2. ViewModel에서 로드한 페이지를 emit
3. Fragment에서 emit한 페이지 데이터 collect
4. PagingDataAdapter(ListAdapter와 유사한 친구)에서 ui 노출
```
paging3 라이브러리를 잘 모른다면 이해하기 어려울 수도 있을 것 같은데 코드 리뷰하면서 마음껏 질문해주셔도 좋습니다~!!!