### PR TITLE
fix: 헤더가 빈 값이면 NPE 발생

### DIFF
--- a/backend/src/main/java/com/ody/auth/token/AccessToken.java
+++ b/backend/src/main/java/com/ody/auth/token/AccessToken.java
@@ -29,7 +29,7 @@ public class AccessToken implements JwtToken {
     }
 
     private void validate(String value) {
-        if (!value.startsWith(ACCESS_TOKEN_PREFIX)) {
+        if (value == null || !value.startsWith(ACCESS_TOKEN_PREFIX)) {
             throw new OdyBadRequestException("잘못된 액세스 토큰 형식입니다.");
         }
     }

--- a/backend/src/main/java/com/ody/auth/token/RefreshToken.java
+++ b/backend/src/main/java/com/ody/auth/token/RefreshToken.java
@@ -22,27 +22,27 @@ public class RefreshToken implements JwtToken {
     @Column(name = "refreshToken")
     private String value;
 
-    public RefreshToken(String rawValue) {
-        validate(rawValue);
-        this.value = parseRefreshToken(rawValue);
-    }
-
-    private void validate(String value) {
-        if (!value.startsWith(REFRESH_TOKEN_PREFIX)) {
-            throw new OdyBadRequestException("잘못된 리프레시 토큰 형식입니다.");
-        }
-    }
-
-    private String parseRefreshToken(String rawValue) {
-        return rawValue.substring(REFRESH_TOKEN_PREFIX.length()).trim();
-    }
-
     public RefreshToken(AuthProperties authProperties) {
         Date validity = new Date(System.currentTimeMillis() + authProperties.getRefreshExpiration());
         this.value = Jwts.builder()
                 .setExpiration(validity)
                 .signWith(SignatureAlgorithm.HS256, authProperties.getRefreshKey())
                 .compact();
+    }
+
+    public RefreshToken(String rawValue) {
+        validate(rawValue);
+        this.value = parseRefreshToken(rawValue);
+    }
+
+    private void validate(String value) {
+        if (value == null || !value.startsWith(REFRESH_TOKEN_PREFIX)) {
+            throw new OdyBadRequestException("잘못된 리프레시 토큰 형식입니다.");
+        }
+    }
+
+    private String parseRefreshToken(String rawValue) {
+        return rawValue.substring(REFRESH_TOKEN_PREFIX.length()).trim();
     }
 
     @Override

--- a/backend/src/test/java/com/ody/auth/token/AccessTokenTest.java
+++ b/backend/src/test/java/com/ody/auth/token/AccessTokenTest.java
@@ -1,0 +1,17 @@
+package com.ody.auth.token;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ody.common.exception.OdyBadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AccessTokenTest {
+
+    @DisplayName("액세스 토큰이 널이면 400 에러가 발생한다.")
+    @Test
+    void nullAccessTokenException() {
+        assertThatThrownBy(() -> new AccessToken(null))
+                .isInstanceOf(OdyBadRequestException.class);
+    }
+}

--- a/backend/src/test/java/com/ody/auth/token/RefreshTokenTest.java
+++ b/backend/src/test/java/com/ody/auth/token/RefreshTokenTest.java
@@ -1,0 +1,17 @@
+package com.ody.auth.token;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ody.common.exception.OdyBadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenTest {
+
+    @DisplayName("리프레시 토큰이 널이면 400 에러가 발생한다.")
+    @Test
+    void nullRefreshTokenException() {
+        assertThatThrownBy(() -> new RefreshToken((String) null))
+                .isInstanceOf(OdyBadRequestException.class);
+    }
+}


### PR DESCRIPTION
# 🚩 연관 이슈 
close #622


<br>

# 📝 작업 내용

헤더가 널일 때 NPE가 발생해 500이 반환되어 안드 측에서 에러 확인 문의가 반복적으로 일어나 해결합니다 

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
