### PR TITLE
refactor: suspendOnXXX() 함수 제거

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/data/auth/repository/KakaoAuthRepository.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/auth/repository/KakaoAuthRepository.kt
@@ -5,7 +5,7 @@ import com.mulberry.ody.data.auth.source.local.LocalAuthDataSource
 import com.mulberry.ody.data.auth.source.remote.RemoteAuthDataSource
 import com.mulberry.ody.domain.apiresult.ApiResult
 import com.mulberry.ody.domain.apiresult.getOrNull
-import com.mulberry.ody.domain.apiresult.suspendOnSuccess
+import com.mulberry.ody.domain.apiresult.onSuccess
 import com.mulberry.ody.domain.model.AuthToken
 import com.mulberry.ody.domain.repository.ody.AuthRepository
 import javax.inject.Inject
@@ -27,7 +27,7 @@ class KakaoAuthRepository
 
         override suspend fun login(context: Context): ApiResult<AuthToken> {
             val fcmToken = localAuthDataSource.fetchFCMToken().getOrNull() ?: return ApiResult.Unexpected(Exception("FCM 토큰이 존재하지 않습니다."))
-            return remoteAuthDataSource.login(fcmToken, context).suspendOnSuccess {
+            return remoteAuthDataSource.login(fcmToken, context).onSuccess {
                 localAuthDataSource.postAuthToken(it)
             }
         }
@@ -38,7 +38,7 @@ class KakaoAuthRepository
         }
 
         override suspend fun withdrawAccount(): ApiResult<Unit> {
-            return remoteAuthDataSource.withdraw().suspendOnSuccess {
+            return remoteAuthDataSource.withdraw().onSuccess {
                 localAuthDataSource.removeAuthToken()
             }
         }

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
@@ -4,9 +4,9 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
+import com.mulberry.ody.domain.apiresult.fold
 import com.mulberry.ody.domain.apiresult.getOrNull
 import com.mulberry.ody.domain.apiresult.onNetworkError
-import com.mulberry.ody.domain.apiresult.suspendFold
 import com.mulberry.ody.domain.model.MateEtaInfo
 import com.mulberry.ody.domain.repository.ody.MeetingRepository
 import com.mulberry.ody.presentation.common.analytics.AnalyticsHelper
@@ -88,7 +88,7 @@ class EtaDashboardService : Service() {
     }
 
     private suspend fun getLocation(meetingId: Long): MateEtaInfo? {
-        return geoLocationHelper.getCurrentCoordinate().suspendFold(
+        return geoLocationHelper.getCurrentCoordinate().fold(
             onSuccess = { location ->
                 updateMatesEta(
                     meetingId,

--- a/android/app/src/main/java/com/mulberry/ody/data/retrofit/AccessTokenInterceptor.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/retrofit/AccessTokenInterceptor.kt
@@ -5,7 +5,7 @@ import com.mulberry.ody.data.remote.core.entity.login.mapper.toAuthToken
 import com.mulberry.ody.data.remote.core.service.RefreshTokenService
 import com.mulberry.ody.domain.apiresult.ApiResult
 import com.mulberry.ody.domain.apiresult.map
-import com.mulberry.ody.domain.apiresult.suspendOnSuccess
+import com.mulberry.ody.domain.apiresult.onSuccess
 import com.mulberry.ody.domain.model.AuthToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -55,7 +55,7 @@ class AccessTokenInterceptor
             runBlocking(Dispatchers.IO) {
                 refreshTokenService.postRefreshToken()
                     .map { it.toAuthToken() }
-                    .suspendOnSuccess {
+                    .onSuccess {
                         odyDatastore.setAuthToken(it)
                     }
             }

--- a/android/app/src/main/java/com/mulberry/ody/domain/apiresult/ApiResultExtensions.kt
+++ b/android/app/src/main/java/com/mulberry/ody/domain/apiresult/ApiResultExtensions.kt
@@ -2,63 +2,35 @@ package com.mulberry.ody.domain.apiresult
 
 import java.lang.IllegalArgumentException
 
-fun <T> ApiResult<T>.onSuccess(block: (T) -> Unit): ApiResult<T> {
+inline fun <T> ApiResult<T>.onSuccess(block: (T) -> Unit): ApiResult<T> {
     if (this is ApiResult.Success) {
         block(this.data)
     }
     return this
 }
 
-fun <T> ApiResult<T>.onFailure(block: (code: Int?, errorMessage: String?) -> Unit): ApiResult<T> {
+inline fun <T> ApiResult<T>.onFailure(block: (code: Int?, errorMessage: String?) -> Unit): ApiResult<T> {
     if (this is ApiResult.Failure) {
         block(this.code, this.errorMessage)
     }
     return this
 }
 
-fun <T> ApiResult<T>.onNetworkError(block: (exception: Exception) -> Unit): ApiResult<T> {
+inline fun <T> ApiResult<T>.onNetworkError(block: (exception: Exception) -> Unit): ApiResult<T> {
     if (this is ApiResult.NetworkError) {
         block(this.exception)
     }
     return this
 }
 
-fun <T> ApiResult<T>.onUnexpected(block: (t: Throwable) -> Unit): ApiResult<T> {
+inline fun <T> ApiResult<T>.onUnexpected(block: (t: Throwable) -> Unit): ApiResult<T> {
     if (this is ApiResult.Unexpected) {
         block(this.t)
     }
     return this
 }
 
-suspend fun <T> ApiResult<T>.suspendOnSuccess(block: suspend (T) -> Unit): ApiResult<T> {
-    if (this is ApiResult.Success) {
-        block(this.data)
-    }
-    return this
-}
-
-suspend fun <T> ApiResult<T>.suspendOnFailure(block: suspend (code: Int?, errorMessage: String?) -> Unit): ApiResult<T> {
-    if (this is ApiResult.Failure) {
-        block(this.code, this.errorMessage)
-    }
-    return this
-}
-
-suspend fun <T> ApiResult<T>.suspendOnNetworkError(block: suspend (exception: Exception) -> Unit): ApiResult<T> {
-    if (this is ApiResult.NetworkError) {
-        block(this.exception)
-    }
-    return this
-}
-
-suspend fun <T> ApiResult<T>.suspendOnUnexpected(block: suspend (t: Throwable) -> Unit): ApiResult<T> {
-    if (this is ApiResult.Unexpected) {
-        block(this.t)
-    }
-    return this
-}
-
-suspend fun <T, R> ApiResult<T>.map(block: suspend (T) -> R): ApiResult<R> {
+inline fun <T, R> ApiResult<T>.map(block: (T) -> R): ApiResult<R> {
     return when (this) {
         is ApiResult.Success -> ApiResult.Success(block(this.data))
         is ApiResult.Failure -> ApiResult.Failure(this.code, this.errorMessage)
@@ -97,9 +69,9 @@ fun <T> ApiResult<T>.exceptionOrNull(): Throwable? {
     return exception
 }
 
-suspend fun <R, T> ApiResult<T>.suspendFold(
-    onSuccess: suspend (data: T) -> R,
-    onFailure: suspend (t: Throwable) -> R,
+inline fun <R, T> ApiResult<T>.fold(
+    onSuccess: (data: T) -> R,
+    onFailure: (t: Throwable) -> R,
 ): R {
     return when (val exception = exceptionOrNull()) {
         null -> onSuccess(this.getOrNull() as T)
@@ -107,7 +79,7 @@ suspend fun <R, T> ApiResult<T>.suspendFold(
     }
 }
 
-suspend fun <T, R> ApiResult<T>.flatMap(block: suspend (T) -> ApiResult<R>): ApiResult<R> {
+inline fun <T, R> ApiResult<T>.flatMap(block: (T) -> ApiResult<R>): ApiResult<R> {
     return when (this) {
         is ApiResult.Success -> block(this.data)
         is ApiResult.Failure -> ApiResult.Failure(this.code, this.errorMessage)

--- a/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/creation/MeetingCreationViewModel.kt
@@ -5,8 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.mulberry.ody.domain.apiresult.onFailure
 import com.mulberry.ody.domain.apiresult.onNetworkError
 import com.mulberry.ody.domain.apiresult.onSuccess
-import com.mulberry.ody.domain.apiresult.suspendOnSuccess
-import com.mulberry.ody.domain.apiresult.suspendOnUnexpected
+import com.mulberry.ody.domain.apiresult.onUnexpected
 import com.mulberry.ody.domain.model.Address
 import com.mulberry.ody.domain.model.MeetingCreationInfo
 import com.mulberry.ody.domain.repository.location.AddressRepository
@@ -116,10 +115,10 @@ class MeetingCreationViewModel
             viewModelScope.launch {
                 startLoading()
                 locationHelper.getCurrentCoordinate()
-                    .suspendOnSuccess { location ->
+                    .onSuccess { location ->
                         fetchAddressesByCoordinate(location)
                     }
-                    .suspendOnUnexpected {
+                    .onUnexpected {
                         _defaultLocationError.emit(Unit)
                     }
                 stopLoading()
@@ -140,7 +139,7 @@ class MeetingCreationViewModel
             }.onFailure { code, errorMessage ->
                 handleError()
                 analyticsHelper.logNetworkErrorEvent(TAG, "$code $errorMessage")
-            }.suspendOnUnexpected {
+            }.onUnexpected {
                 _defaultLocationError.emit(Unit)
             }.onNetworkError {
                 handleNetworkError()

--- a/android/app/src/main/java/com/mulberry/ody/presentation/invitecode/InviteCodeViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/invitecode/InviteCodeViewModel.kt
@@ -1,9 +1,9 @@
 package com.mulberry.ody.presentation.invitecode
 
 import androidx.lifecycle.viewModelScope
+import com.mulberry.ody.domain.apiresult.onFailure
 import com.mulberry.ody.domain.apiresult.onNetworkError
-import com.mulberry.ody.domain.apiresult.suspendOnFailure
-import com.mulberry.ody.domain.apiresult.suspendOnSuccess
+import com.mulberry.ody.domain.apiresult.onSuccess
 import com.mulberry.ody.domain.repository.ody.MeetingRepository
 import com.mulberry.ody.presentation.common.BaseViewModel
 import com.mulberry.ody.presentation.common.analytics.AnalyticsHelper
@@ -51,9 +51,9 @@ class InviteCodeViewModel
                 val inviteCode = inviteCode.value.ifBlank { return@launch }
                 startLoading()
                 meetingRepository.fetchInviteCodeValidity(inviteCode)
-                    .suspendOnSuccess {
+                    .onSuccess {
                         _navigateAction.emit(InviteCodeNavigateAction.CodeNavigateToJoin)
-                    }.suspendOnFailure { code, errorMessage ->
+                    }.onFailure { code, errorMessage ->
                         _invalidCodeEvent.emit(errorMessage.toString())
                         analyticsHelper.logNetworkErrorEvent(TAG, "$code $errorMessage")
                     }.onNetworkError {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/join/MeetingJoinViewModel.kt
@@ -5,8 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.mulberry.ody.domain.apiresult.onFailure
 import com.mulberry.ody.domain.apiresult.onNetworkError
 import com.mulberry.ody.domain.apiresult.onSuccess
-import com.mulberry.ody.domain.apiresult.suspendOnSuccess
-import com.mulberry.ody.domain.apiresult.suspendOnUnexpected
+import com.mulberry.ody.domain.apiresult.onUnexpected
 import com.mulberry.ody.domain.model.Address
 import com.mulberry.ody.domain.model.MeetingJoinInfo
 import com.mulberry.ody.domain.repository.location.AddressRepository
@@ -65,10 +64,10 @@ class MeetingJoinViewModel
             viewModelScope.launch {
                 startLoading()
                 locationHelper.getCurrentCoordinate()
-                    .suspendOnSuccess { location ->
+                    .onSuccess { location ->
                         fetchAddressesByCoordinate(location)
                     }
-                    .suspendOnUnexpected {
+                    .onUnexpected {
                         _defaultLocationError.emit(Unit)
                     }
                 stopLoading()
@@ -89,7 +88,7 @@ class MeetingJoinViewModel
             }.onFailure { code, errorMessage ->
                 handleError()
                 analyticsHelper.logNetworkErrorEvent(TAG, "$code $errorMessage")
-            }.suspendOnUnexpected {
+            }.onUnexpected {
                 _defaultLocationError.emit(Unit)
             }.onNetworkError {
                 handleNetworkError()
@@ -106,7 +105,7 @@ class MeetingJoinViewModel
             viewModelScope.launch {
                 startLoading()
                 joinRepository.postMates(meetingJoinInfo)
-                    .suspendOnSuccess {
+                    .onSuccess {
                         matesEtaRepository.reserveEtaFetchingJob(it.meetingId, it.meetingDateTime)
                         _navigateAction.emit(MeetingJoinNavigateAction.JoinNavigateToRoom(it.meetingId))
                         _navigateAction.emit(MeetingJoinNavigateAction.JoinNavigateToJoinComplete)

--- a/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/login/LoginViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.mulberry.ody.domain.apiresult.onFailure
 import com.mulberry.ody.domain.apiresult.onNetworkError
-import com.mulberry.ody.domain.apiresult.suspendOnSuccess
+import com.mulberry.ody.domain.apiresult.onSuccess
 import com.mulberry.ody.domain.repository.ody.AuthRepository
 import com.mulberry.ody.domain.repository.ody.MatesEtaRepository
 import com.mulberry.ody.presentation.common.BaseViewModel
@@ -55,7 +55,7 @@ class LoginViewModel
             viewModelScope.launch {
                 startLoading()
                 authRepository.login(context)
-                    .suspendOnSuccess {
+                    .onSuccess {
                         navigateToMeetings()
                         matesEtaRepository.reserveAllEtaReservation()
                     }.onFailure { code, errorMessage ->

--- a/android/app/src/main/java/com/mulberry/ody/presentation/room/MeetingRoomViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/room/MeetingRoomViewModel.kt
@@ -10,8 +10,6 @@ import com.mulberry.ody.domain.apiresult.onFailure
 import com.mulberry.ody.domain.apiresult.onNetworkError
 import com.mulberry.ody.domain.apiresult.onSuccess
 import com.mulberry.ody.domain.apiresult.onUnexpected
-import com.mulberry.ody.domain.apiresult.suspendOnFailure
-import com.mulberry.ody.domain.apiresult.suspendOnSuccess
 import com.mulberry.ody.domain.model.MateEtaInfo
 import com.mulberry.ody.domain.model.Nudge
 import com.mulberry.ody.domain.repository.image.ImageStorage
@@ -145,9 +143,9 @@ class MeetingRoomViewModel
             mateNickname: String,
         ) {
             meetingRepository.postNudge(Nudge(nudgeId, mateId))
-                .suspendOnSuccess {
+                .onSuccess {
                     _nudgeSuccessMate.emit(mateNickname)
-                }.suspendOnFailure { code, errorMessage ->
+                }.onFailure { code, errorMessage ->
                     when (code) {
                         400 -> _expiredNudgeTimeLimit.emit(Unit)
                         else -> handleError()
@@ -275,7 +273,7 @@ class MeetingRoomViewModel
 
                 startLoading()
                 meetingRepository.exitMeeting(_meeting.value.id)
-                    .suspendOnSuccess {
+                    .onSuccess {
                         matesEtaRepository.deleteEtaReservation(meetingId)
                         _exitMeetingRoomEvent.emit(Unit)
                     }.onFailure { code, errorMessage ->

--- a/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/setting/SettingViewModel.kt
@@ -3,7 +3,7 @@ package com.mulberry.ody.presentation.setting
 import androidx.lifecycle.viewModelScope
 import com.mulberry.ody.domain.apiresult.onFailure
 import com.mulberry.ody.domain.apiresult.onNetworkError
-import com.mulberry.ody.domain.apiresult.suspendOnSuccess
+import com.mulberry.ody.domain.apiresult.onSuccess
 import com.mulberry.ody.domain.repository.ody.AuthRepository
 import com.mulberry.ody.domain.repository.ody.MatesEtaRepository
 import com.mulberry.ody.presentation.common.BaseViewModel
@@ -42,7 +42,7 @@ class SettingViewModel
             viewModelScope.launch {
                 startLoading()
                 authRepository.withdrawAccount()
-                    .suspendOnSuccess {
+                    .onSuccess {
                         _loginNavigateEvent.emit(LoginNavigatedReason.WITHDRAWAL)
                         matesEtaRepository.clearEtaFetchingJob()
                         matesEtaRepository.clearEtaReservation(isReservationPending = false)


### PR DESCRIPTION
# 🚩 연관 이슈 
close #948 


<br>

# 📝 작업 내용
- [x] ApiResultExtensions의 suspend 키워드 제거 -> inline 키워드 추가

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
`suspendOnXXX()`랑 `onXXX()` 함수가 두개씩 있는게 유지보수성과 가독성이 좋지 않은 것 같아서
코틀린의 `Result`의 `onXXX()`는 어떻게 구현되어있는지 찾아봤어요.
그런데 `suspend` 처리에 관련된 로직은 안보이고 그냥 `inline` 키워드가 붙어있더라구요 ..
람다가 호출한 쪽에 `inline`되는 거면 호출한 쪽의 컨텍스트에 따라 `suspend` 함수를 호출할 수 있으니 `suspendOnXXX()`를 굳이 만들 필요가 없었어요!

추가적으로 `ApiResultExtensions`에서 `suspend` 붙은 함수들 모두 적용했습니다.
호출하는 쪽에서 `suspend`인지 아닌지에 따라 호출할 함수를 결정하는 건 좋지 못한 방식인 것 같아서요 ...
넘 간단하게 해결해서 기분 좋음 ㅎ