### PR TITLE
design: 날짜/시간 문구 형식 변경

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/presentation/common/LocalDateTimeMapper.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/common/LocalDateTimeMapper.kt
@@ -1,0 +1,35 @@
+package com.mulberry.ody.presentation.common
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAccessor
+import java.util.Locale
+
+private const val DATE_TIME_PATTERN = "yyyy년 M월 d일 a h시 m분"
+private const val DATE_PATTERN = "yyyy년 M월 d일"
+private const val TIME_PATTERN = "a h시 m분"
+
+private const val HOUR_MINUTE_PATTERN = "h시 m분"
+private const val MINUTE_PATTERN = "m분"
+
+fun LocalDateTime.toMessage(): String = format(DATE_TIME_PATTERN)
+
+fun LocalDate.toMessage(): String = format(DATE_PATTERN)
+
+fun LocalTime.toMessage(): String = format(TIME_PATTERN)
+
+fun Int.toRemainingTimeMessage(): String {
+    val hour = this / 60
+    val minute = this % 60
+    val localTime = LocalTime.of(hour, minute)
+    val pattern = if (hour == 0) MINUTE_PATTERN else HOUR_MINUTE_PATTERN
+    return localTime.format(pattern)
+}
+
+private fun TemporalAccessor.format(pattern: String): String {
+    return DateTimeFormatter.ofPattern(pattern)
+        .withLocale(Locale.forLanguageTag("ko"))
+        .format(this)
+}

--- a/android/app/src/main/java/com/mulberry/ody/presentation/common/LocalDateTimeMapper.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/common/LocalDateTimeMapper.kt
@@ -1,9 +1,11 @@
 package com.mulberry.ody.presentation.common
 
+import java.lang.IllegalArgumentException
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import java.time.temporal.TemporalAccessor
 import java.util.Locale
 
@@ -32,4 +34,13 @@ private fun TemporalAccessor.format(pattern: String): String {
     return DateTimeFormatter.ofPattern(pattern)
         .withLocale(Locale.forLanguageTag("ko"))
         .format(this)
+}
+
+fun String.toLocalDateTime(): LocalDateTime {
+    val formatter = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN)
+    return try {
+        LocalDateTime.parse(this, formatter)
+    } catch (e: DateTimeParseException) {
+        throw IllegalArgumentException("LocalDateTime으로 변환할 수 없는 문자열입니다. ($this)")
+    }
 }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/meetings/MeetingsBindingAdapter.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/meetings/MeetingsBindingAdapter.kt
@@ -3,6 +3,7 @@ package com.mulberry.ody.presentation.meetings
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import com.mulberry.ody.R
+import com.mulberry.ody.presentation.common.toMessage
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -32,17 +33,12 @@ fun TextView.showDateTime(dateTime: LocalDateTime) {
                 )
             }
 
-            else -> {
-                DateTimeFormatter.ofPattern("yyyy년 M월 d일").format(dateTime)
-            }
+            else -> dateTime.toLocalDate().toMessage()
         }
-    val meetingTime = dateTime.toLocalTime()
     if (!(isToday || isTomorrow)) {
         this.text = dateString
         return
     }
-    val timeString =
-        DateTimeFormatter.ofPattern("a h시 mm분").withLocale(Locale.forLanguageTag("ko"))
-            .format(meetingTime)
+    val timeString = dateTime.toLocalTime().toMessage()
     this.text = "$dateString $timeString"
 }

--- a/android/app/src/main/java/com/mulberry/ody/presentation/meetings/MeetingsBindingAdapter.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/meetings/MeetingsBindingAdapter.kt
@@ -5,8 +5,6 @@ import androidx.databinding.BindingAdapter
 import com.mulberry.ody.R
 import com.mulberry.ody.presentation.common.toMessage
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 @BindingAdapter("showDateTime")
 fun TextView.showDateTime(dateTime: LocalDateTime) {

--- a/android/app/src/main/java/com/mulberry/ody/presentation/room/detail/model/DetailMeetingUiModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/room/detail/model/DetailMeetingUiModel.kt
@@ -2,7 +2,6 @@ package com.mulberry.ody.presentation.room.detail.model
 
 import com.mulberry.ody.presentation.common.toLocalDateTime
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 data class DetailMeetingUiModel(
     val id: Long,

--- a/android/app/src/main/java/com/mulberry/ody/presentation/room/detail/model/DetailMeetingUiModel.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/room/detail/model/DetailMeetingUiModel.kt
@@ -1,5 +1,6 @@
 package com.mulberry.ody.presentation.room.detail.model
 
+import com.mulberry.ody.presentation.common.toLocalDateTime
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -15,15 +16,13 @@ data class DetailMeetingUiModel(
     val inviteCode: String,
 ) {
     fun isEtaAccessible(): Boolean {
-        val formatter = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN)
-        val localDateTime = LocalDateTime.parse(dateTime, formatter)
+        val localDateTime = dateTime.toLocalDateTime()
         return localDateTime.minusMinutes(ETA_ACCESSIBLE_MINUTE) <= LocalDateTime.now()
     }
 
     fun isDefault(): Boolean = this == DEFAULT
 
     companion object {
-        const val DATE_TIME_PATTERN = "yyyy년 M월 d일 HH시 mm분"
         private const val ETA_ACCESSIBLE_MINUTE = 30L
 
         val DEFAULT: DetailMeetingUiModel =

--- a/android/app/src/main/java/com/mulberry/ody/presentation/room/detail/model/DetailMeetingUiModelMapper.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/room/detail/model/DetailMeetingUiModelMapper.kt
@@ -1,40 +1,20 @@
 package com.mulberry.ody.presentation.room.detail.model
 
 import com.mulberry.ody.domain.model.Meeting
+import com.mulberry.ody.presentation.common.toMessage
+import com.mulberry.ody.presentation.common.toRemainingTimeMessage
 import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.format.DateTimeFormatter
 
 fun Meeting.toDetailMeetingUiModel(): DetailMeetingUiModel {
     return DetailMeetingUiModel(
         id = id,
         name = name,
-        dateTime = this.toDateTimeString(),
+        dateTime = LocalDateTime.of(date, time).toMessage(),
         destinationAddress = departureAddress,
         departureAddress = destinationAddress,
-        departureTime = departureTime.toTimeString(),
-        routeTime = routeTime.toTimeString(),
+        departureTime = departureTime.toMessage(),
+        routeTime = routeTime.toRemainingTimeMessage(),
         mates = mates.map { it.nickname },
         inviteCode = inviteCode,
     )
-}
-
-private fun Meeting.toDateTimeString(): String {
-    val dateTime = LocalDateTime.of(date, time)
-    val dateTimeFormatter = DateTimeFormatter.ofPattern(DetailMeetingUiModel.DATE_TIME_PATTERN)
-    return dateTime.format(dateTimeFormatter)
-}
-
-private fun LocalTime.toTimeString(): String {
-    val dateTimeFormatter = DateTimeFormatter.ofPattern("HH시 mm분")
-    return format(dateTimeFormatter)
-}
-
-private fun Int.toTimeString(): String {
-    val hour = this / 60
-    val minute = this % 60
-    val localTime = LocalTime.of(hour, minute)
-    val formatterPattern = if (hour == 0) "mm분" else "HH시 mm분"
-    val dateTimeFormatter = DateTimeFormatter.ofPattern(formatterPattern)
-    return localTime.format(dateTimeFormatter)
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #962


<br>

# 📝 작업 내용
- [x] 날짜 - 2025년 2월 1일
- [x] 시간 - 오후 1시 1분
- [x] 피그마에 반영

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
저번 회의(해음 없었을 때 ㅠ) 때 결정한 날짜/시간 형식을 모든 화면에 통일시켰습니다!
현재는 notification localDateTime만 형식이 달라서, 그건 util 함수로 빼지 않고 notification 관련 로직으로 두었어요