### PR TITLE
design: 도착지까지 걸리는 시간 문구 수정

### DIFF
--- a/android/app/src/main/java/com/mulberry/ody/presentation/common/LocalDateTimeMapper.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/common/LocalDateTimeMapper.kt
@@ -13,7 +13,7 @@ private const val DATE_TIME_PATTERN = "yyyy년 M월 d일 a h시 m분"
 private const val DATE_PATTERN = "yyyy년 M월 d일"
 private const val TIME_PATTERN = "a h시 m분"
 
-private const val HOUR_MINUTE_PATTERN = "h시 m분"
+private const val HOUR_MINUTE_PATTERN = "h시간 m분"
 private const val MINUTE_PATTERN = "m분"
 
 fun LocalDateTime.toMessage(): String = format(DATE_TIME_PATTERN)

--- a/android/app/src/main/java/com/mulberry/ody/presentation/meetings/model/MeetingUiModelMapper.kt
+++ b/android/app/src/main/java/com/mulberry/ody/presentation/meetings/model/MeetingUiModelMapper.kt
@@ -1,16 +1,17 @@
 package com.mulberry.ody.presentation.meetings.model
 
 import com.mulberry.ody.domain.model.MeetingCatalog
+import com.mulberry.ody.presentation.common.toDurationTimeMessage
 import java.time.LocalDateTime
 
 fun MeetingCatalog.toMeetingCatalogUiModel(): MeetingUiModel {
     val now = LocalDateTime.now()
     val inDuration = datetime.isBefore(now.plusMinutes(30))
     return MeetingUiModel(
+        id = id,
         name = name,
         datetime = datetime,
-        durationMinutes = durationMinutes.toString(),
-        id = id,
+        durationMinutes = durationMinutes.toInt().toDurationTimeMessage(),
         originAddress = originAddress,
         targetAddress = targetAddress,
         isEnabled = inDuration,

--- a/android/app/src/main/res/layout/item_meeting_catalog.xml
+++ b/android/app/src/main/res/layout/item_meeting_catalog.xml
@@ -148,7 +148,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="@id/tv_meeting_title_expanded"
             app:layout_constraintTop_toBottomOf="@id/layout_departure_arrival"
-            tools:text="15분 걸려요" />
+            tools:text="1시간 10분 걸려요" />
 
         <TextView
             style="@style/pretendard_regular_12"
@@ -161,7 +161,6 @@
             app:layout_constraintStart_toStartOf="@id/tv_meeting_eta"
             app:layout_constraintTop_toBottomOf="@id/tv_meeting_eta"
             tools:text="*대중교통 기준" />
-
 
         <include
             layout="@layout/layout_navigate_to_eta"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="meetings_traffic_guide">*대중교통 기준</string>
     <string name="meetings_departure_postfix">에서</string>
     <string name="meetings_arrival_postfix">까지</string>
-    <string name="meetings_eta_form">%1$s분 걸려요</string>
+    <string name="meetings_eta_form">%s 걸려요</string>
     <string name="meetings_today">오늘</string>
     <string name="meetings_tomorrow">내일</string>
     <string name="meetings_post_tomorrow">%1$s일 후</string>


### PR DESCRIPTION
# 🚩 연관 이슈 
close #971


<br>

# 📝 작업 내용
- [x] 상세 화면 : X시 X분 걸려요 -> X시간 X분 걸려요
- [x] 메인 화면: X분 걸려요 -> X시간 X분 걸려요

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
도착지까지 걸리는 시간이 70분인 경우, 
메인화면에서는 "70분 걸려요"라고 뜨고 상세 화면에는 "1시 10분 걸려요"라고 뜨는 오타가 있어서 수정했습니다 ㅜ!!!! 바보같은 실수를...