### PR TITLE
refactor: meetingLog 도메인 추가

### DIFF
--- a/backend/src/main/java/com/ody/mate/service/MateService.java
+++ b/backend/src/main/java/com/ody/mate/service/MateService.java
@@ -83,16 +83,22 @@ public class MateService {
         DepartureReminder departureReminder = new DepartureReminder(mate, departureTime, fcmTopic);
         Notification savedDepartureReminder = notificationService.save(departureReminder.toNotification());
         LocalDateTime sendAt = savedDepartureReminder.getSendAt();
+        saveDepartureReminderLog(mate, sendAt);
 
         scheduleRunner.runWithTransaction(() -> {
             Mate savedMate = findFetchedMate(mate.getId());
-            boolean sended = notificationService.send(savedDepartureReminder);
-            if (sended) {
+            boolean isSent = notificationService.send(savedDepartureReminder);
+            if (isSent) {
                 MeetingLog departureReminderLog = new MeetingLog(savedMate, MeetingLogType.DEPARTURE_REMINDER);
                 meetingLogService.save(departureReminderLog);
             }
         }, sendAt);
         log.info("출발 리마인더 {}에 스케줄링 예약", sendAt);
+    }
+
+    private void saveDepartureReminderLog(Mate mate, LocalDateTime showAt) {
+        MeetingLog departureReminderLog = new MeetingLog(mate, MeetingLogType.DEPARTURE_REMINDER, showAt);
+        meetingLogService.save(departureReminderLog);
     }
 
     private void validateMeetingOverdue(Meeting meeting) {

--- a/backend/src/main/java/com/ody/mate/service/MateService.java
+++ b/backend/src/main/java/com/ody/mate/service/MateService.java
@@ -13,6 +13,9 @@ import com.ody.mate.repository.MateRepository;
 import com.ody.meeting.domain.Coordinates;
 import com.ody.meeting.domain.Meeting;
 import com.ody.meeting.dto.response.MateEtaResponsesV2;
+import com.ody.meetinglog.domain.MeetingLog;
+import com.ody.meetinglog.domain.MeetingLogType;
+import com.ody.meetinglog.service.MeetingLogService;
 import com.ody.member.domain.Member;
 import com.ody.notification.domain.FcmTopic;
 import com.ody.notification.domain.Notification;
@@ -40,6 +43,7 @@ public class MateService {
     private static final long AVAILABLE_NUDGE_DURATION = 30L;
 
     private final MateRepository mateRepository;
+    private final MeetingLogService meetingLogService;
     private final EtaService etaService;
     private final NotificationService notificationService;
     private final RouteService routeService;
@@ -159,16 +163,16 @@ public class MateService {
 
     @Transactional
     public void withdraw(Mate mate) {
-        Notification memberDeletionNotification = new MemberDeletion(mate).toNotification();
-        notificationService.save(memberDeletionNotification);
+        MeetingLog deletionLog = new MeetingLog(mate, MeetingLogType.MEMBER_DELETION_LOG);
+        meetingLogService.save(deletionLog);
         delete(mate);
     }
 
     @Transactional
     public void leaveByMeetingIdAndMemberId(Long meetingId, Long memberId) {
         Mate mate = findByMeetingIdAndMemberId(meetingId, memberId);
-        Notification leaveNotification = new MateLeave(mate).toNotification();
-        notificationService.save(leaveNotification);
+        MeetingLog leaveLog = new MeetingLog(mate, MeetingLogType.LEAVE_LOG);
+        meetingLogService.save(leaveLog);
         delete(mate);
     }
 

--- a/backend/src/main/java/com/ody/mate/service/MateService.java
+++ b/backend/src/main/java/com/ody/mate/service/MateService.java
@@ -158,7 +158,7 @@ public class MateService {
         return etaStatus == EtaStatus.LATE_WARNING || etaStatus == EtaStatus.LATE;
     }
 
-    private Mate findFetchedMate(Long mateId) {
+    private Mate findFetchedMate(long mateId) {
         Mate mate = mateRepository.findFetchedMateById(mateId)
                 .orElseThrow(() -> new OdyBadRequestException("존재하지 않는 약속 참여자입니다."));
         if (mate.getMeeting().isOverdue()) {

--- a/backend/src/main/java/com/ody/mate/service/MateService.java
+++ b/backend/src/main/java/com/ody/mate/service/MateService.java
@@ -92,7 +92,7 @@ public class MateService {
                 meetingLogService.save(departureReminderLog);
             }
         }, sendAt);
-        log.info("출발 알림 알림 {}에 스케줄링 예약", sendAt);
+        log.info("출발 리마인더 {}에 스케줄링 예약", sendAt);
     }
 
     private void validateMeetingOverdue(Meeting meeting) {

--- a/backend/src/main/java/com/ody/mate/service/MateService.java
+++ b/backend/src/main/java/com/ody/mate/service/MateService.java
@@ -107,6 +107,10 @@ public class MateService {
         Mate requestMate = findFetchedMate(nudgeRequest.requestMateId());
         Mate nudgedMate = findFetchedMate(nudgeRequest.nudgedMateId());
         validateNudgeCondition(requestMate, nudgedMate);
+
+        MeetingLog nudgeLog = new MeetingLog(nudgedMate, MeetingLogType.NUDGE_LOG);
+        meetingLogService.save(nudgeLog);
+
         Nudge nudge = new Nudge(nudgedMate);
         notificationService.sendNudgeMessage(requestMate, nudge);
     }

--- a/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
+++ b/backend/src/main/java/com/ody/meeting/controller/MeetingController.java
@@ -10,6 +10,7 @@ import com.ody.meeting.dto.response.MeetingSaveResponseV1;
 import com.ody.meeting.dto.response.MeetingWithMatesResponseV1;
 import com.ody.meeting.dto.response.MeetingWithMatesResponseV2;
 import com.ody.meeting.service.MeetingService;
+import com.ody.meetinglog.service.MeetingLogService;
 import com.ody.member.domain.Member;
 import com.ody.notification.dto.response.NotiLogFindResponses;
 import com.ody.notification.service.NotificationService;
@@ -33,6 +34,7 @@ public class MeetingController implements MeetingControllerSwagger {
     private final MeetingService meetingService;
     private final MateService mateService;
     private final NotificationService notificationService;
+    private final MeetingLogService meetingLogService;
 
     @Override
     @PostMapping("/v1/meetings")
@@ -77,7 +79,7 @@ public class MeetingController implements MeetingControllerSwagger {
             @AuthMember Member member,
             @PathVariable Long meetingId
     ) {
-        NotiLogFindResponses response = notificationService.findAllNotiLogs(meetingId);
+        NotiLogFindResponses response = meetingLogService.findAllByMeetingId(meetingId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/ody/meetinglog/domain/MeetingLog.java
+++ b/backend/src/main/java/com/ody/meetinglog/domain/MeetingLog.java
@@ -1,0 +1,40 @@
+package com.ody.meetinglog.domain;
+
+import com.ody.common.domain.BaseEntity;
+import com.ody.mate.domain.Mate;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class MeetingLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @JoinColumn(name = "mate_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Mate mate;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private MeetingLogType type;
+
+    public MeetingLog(Mate mate, MeetingLogType type) {
+        this(null, mate, type);
+    }
+}

--- a/backend/src/main/java/com/ody/meetinglog/domain/MeetingLog.java
+++ b/backend/src/main/java/com/ody/meetinglog/domain/MeetingLog.java
@@ -14,8 +14,10 @@ import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PUBLIC)

--- a/backend/src/main/java/com/ody/meetinglog/domain/MeetingLog.java
+++ b/backend/src/main/java/com/ody/meetinglog/domain/MeetingLog.java
@@ -43,7 +43,11 @@ public class MeetingLog extends BaseEntity {
     @Column(columnDefinition = "TIMESTAMP(6)")
     private LocalDateTime showAt;
 
+    public MeetingLog(Mate mate, MeetingLogType type, LocalDateTime showAt) {
+        this(null, mate, type, showAt);
+    }
+
     public MeetingLog(Mate mate, MeetingLogType type) {
-        this(null, mate, type, TimeUtil.nowWithTrim());
+        this(mate, type, TimeUtil.nowWithTrim());
     }
 }

--- a/backend/src/main/java/com/ody/meetinglog/domain/MeetingLog.java
+++ b/backend/src/main/java/com/ody/meetinglog/domain/MeetingLog.java
@@ -48,6 +48,6 @@ public class MeetingLog extends BaseEntity {
     }
 
     public MeetingLog(Mate mate, MeetingLogType type) {
-        this(mate, type, TimeUtil.nowWithTrim());
+        this(mate, type, LocalDateTime.now());
     }
 }

--- a/backend/src/main/java/com/ody/meetinglog/domain/MeetingLog.java
+++ b/backend/src/main/java/com/ody/meetinglog/domain/MeetingLog.java
@@ -2,6 +2,8 @@ package com.ody.meetinglog.domain;
 
 import com.ody.common.domain.BaseEntity;
 import com.ody.mate.domain.Mate;
+import com.ody.util.TimeUtil;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -12,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -36,7 +39,11 @@ public class MeetingLog extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private MeetingLogType type;
 
+    @NotNull
+    @Column(columnDefinition = "TIMESTAMP(6)")
+    private LocalDateTime showAt;
+
     public MeetingLog(Mate mate, MeetingLogType type) {
-        this(null, mate, type);
+        this(null, mate, type, TimeUtil.nowWithTrim());
     }
 }

--- a/backend/src/main/java/com/ody/meetinglog/domain/MeetingLogType.java
+++ b/backend/src/main/java/com/ody/meetinglog/domain/MeetingLogType.java
@@ -1,0 +1,18 @@
+package com.ody.meetinglog.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MeetingLogType {
+
+    ENTRY_LOG("ENTRY"),
+    NUDGE_LOG("NUDGE"),
+    LEAVE_LOG("LEAVE"),
+    MEMBER_DELETION_LOG("MEMBER_DELETION"),
+    DEPARTURE_REMINDER("DEPARTURE_REMINDER"),
+    ;
+
+    private final String name;
+}

--- a/backend/src/main/java/com/ody/meetinglog/repository/MeetingLogRepository.java
+++ b/backend/src/main/java/com/ody/meetinglog/repository/MeetingLogRepository.java
@@ -14,5 +14,5 @@ public interface MeetingLogRepository extends JpaRepository<MeetingLog, Long> {
              where meetingLog.mate.meeting.id = :meetingId
                          and meetingLog.showAt <= :time
             """)
-    List<MeetingLog> findMeetingLogsBeforeThanEqual(long meetingId, LocalDateTime time);
+    List<MeetingLog> findByShowAtBeforeOrEqualTo(long meetingId, LocalDateTime time);
 }

--- a/backend/src/main/java/com/ody/meetinglog/repository/MeetingLogRepository.java
+++ b/backend/src/main/java/com/ody/meetinglog/repository/MeetingLogRepository.java
@@ -1,6 +1,7 @@
 package com.ody.meetinglog.repository;
 
 import com.ody.meetinglog.domain.MeetingLog;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,6 +12,7 @@ public interface MeetingLogRepository extends JpaRepository<MeetingLog, Long> {
             select meetingLog
              from MeetingLog meetingLog
              where meetingLog.mate.meeting.id = :meetingId
+                         and meetingLog.showAt <= :time
             """)
-    List<MeetingLog> findByMeetingId(long meetingId);
+    List<MeetingLog> findMeetingLogsBeforeThanEqual(long meetingId, LocalDateTime time);
 }

--- a/backend/src/main/java/com/ody/meetinglog/repository/MeetingLogRepository.java
+++ b/backend/src/main/java/com/ody/meetinglog/repository/MeetingLogRepository.java
@@ -1,0 +1,16 @@
+package com.ody.meetinglog.repository;
+
+import com.ody.meetinglog.domain.MeetingLog;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface MeetingLogRepository extends JpaRepository<MeetingLog, Long> {
+
+    @Query("""
+            select meetingLog
+             from MeetingLog meetingLog
+             where meetingLog.mate.meeting.id = :meetingId
+            """)
+    List<MeetingLog> findByMeetingId(long meetingId);
+}

--- a/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
+++ b/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
@@ -2,6 +2,7 @@ package com.ody.meetinglog.service;
 
 import com.ody.meetinglog.domain.MeetingLog;
 import com.ody.meetinglog.repository.MeetingLogRepository;
+import com.ody.notification.dto.response.NotiLogFindResponses;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +17,8 @@ public class MeetingLogService {
         return meetingLogRepository.save(meetingLog);
     }
 
-    public List<MeetingLog> findAllByMeetingId(long meetingId) {
-        return meetingLogRepository.findByMeetingId(meetingId);
+    public NotiLogFindResponses findAllByMeetingId(long meetingId) {
+        List<MeetingLog> meetingLogs = meetingLogRepository.findByMeetingId(meetingId);
+        return NotiLogFindResponses.from(meetingLogs);
     }
 }

--- a/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
+++ b/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
@@ -23,8 +23,7 @@ public class MeetingLogService {
     }
 
     public NotiLogFindResponses findAllByMeetingId(long meetingId) {
-        LocalDateTime now = TimeUtil.nowWithTrim();
-        List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meetingId, now);
+        List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meetingId, LocalDateTime.now());
         return NotiLogFindResponses.from(meetingLogs);
     }
 }

--- a/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
+++ b/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
@@ -3,6 +3,8 @@ package com.ody.meetinglog.service;
 import com.ody.meetinglog.domain.MeetingLog;
 import com.ody.meetinglog.repository.MeetingLogRepository;
 import com.ody.notification.dto.response.NotiLogFindResponses;
+import com.ody.util.TimeUtil;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,7 +23,8 @@ public class MeetingLogService {
     }
 
     public NotiLogFindResponses findAllByMeetingId(long meetingId) {
-        List<MeetingLog> meetingLogs = meetingLogRepository.findByMeetingId(meetingId);
+        LocalDateTime now = TimeUtil.nowWithTrim();
+        List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meetingId, now);
         return NotiLogFindResponses.from(meetingLogs);
     }
 }

--- a/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
+++ b/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
@@ -3,7 +3,6 @@ package com.ody.meetinglog.service;
 import com.ody.meetinglog.domain.MeetingLog;
 import com.ody.meetinglog.repository.MeetingLogRepository;
 import com.ody.notification.dto.response.NotiLogFindResponses;
-import com.ody.util.TimeUtil;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +22,7 @@ public class MeetingLogService {
     }
 
     public NotiLogFindResponses findAllByMeetingId(long meetingId) {
-        List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meetingId, LocalDateTime.now());
+        List<MeetingLog> meetingLogs = meetingLogRepository.findByShowAtBeforeOrEqualTo(meetingId, LocalDateTime.now());
         return NotiLogFindResponses.from(meetingLogs);
     }
 }

--- a/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
+++ b/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
@@ -1,0 +1,22 @@
+package com.ody.meetinglog.service;
+
+import com.ody.meetinglog.domain.MeetingLog;
+import com.ody.meetinglog.repository.MeetingLogRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingLogService {
+
+    private final MeetingLogRepository meetingLogRepository;
+
+    public MeetingLog save(MeetingLog meetingLog) {
+        return meetingLogRepository.save(meetingLog);
+    }
+
+    public List<MeetingLog> findAllByMeetingId(long meetingId) {
+        return meetingLogRepository.findByMeetingId(meetingId);
+    }
+}

--- a/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
+++ b/backend/src/main/java/com/ody/meetinglog/service/MeetingLogService.java
@@ -6,13 +6,16 @@ import com.ody.notification.dto.response.NotiLogFindResponses;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MeetingLogService {
 
     private final MeetingLogRepository meetingLogRepository;
 
+    @Transactional
     public MeetingLog save(MeetingLog meetingLog) {
         return meetingLogRepository.save(meetingLog);
     }

--- a/backend/src/main/java/com/ody/notification/dto/response/NotiLogFindResponse.java
+++ b/backend/src/main/java/com/ody/notification/dto/response/NotiLogFindResponse.java
@@ -1,5 +1,7 @@
 package com.ody.notification.dto.response;
 
+import com.ody.mate.domain.Mate;
+import com.ody.meetinglog.domain.MeetingLog;
 import com.ody.notification.domain.Notification;
 import com.ody.util.TimeUtil;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,15 +22,16 @@ public record NotiLogFindResponse(
         String imageUrl
 ) {
 
-    public static NotiLogFindResponse from(Notification notification) {
-        String imageUrl = notification.getMate().getMember().getImageUrl();
-        if (notification.getMate().isDeleted()) {
+    public static NotiLogFindResponse from(MeetingLog meetingLog) {
+        Mate mate = meetingLog.getMate();
+        String imageUrl = mate.getMember().getImageUrl();
+        if(mate.isDeleted()){
             imageUrl = "";
         }
         return new NotiLogFindResponse(
-                notification.getType().toString(),
-                notification.getMate().getNickname().getValue(),
-                TimeUtil.trimSecondsAndNanos(notification.getSendAt()),
+                meetingLog.getType().getName(),
+                mate.getNickname().getValue(),
+                TimeUtil.trimSecondsAndNanos(meetingLog.getCreatedAt()),
                 imageUrl
         );
     }

--- a/backend/src/main/java/com/ody/notification/dto/response/NotiLogFindResponses.java
+++ b/backend/src/main/java/com/ody/notification/dto/response/NotiLogFindResponses.java
@@ -1,6 +1,6 @@
 package com.ody.notification.dto.response;
 
-import com.ody.notification.domain.Notification;
+import com.ody.meetinglog.domain.MeetingLog;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -11,10 +11,10 @@ public record NotiLogFindResponses(
         @ArraySchema(schema = @Schema(description = "로그 목록", implementation = NotiLogFindResponse.class))
         List<NotiLogFindResponse> notiLog
 ) {
-
-    public static NotiLogFindResponses from(List<Notification> notifications) {
-        return notifications.stream()
+    public static NotiLogFindResponses from(List<MeetingLog> meetingLogs) {
+        return meetingLogs.stream()
                 .map(NotiLogFindResponse::from)
                 .collect(Collectors.collectingAndThen(Collectors.toList(), NotiLogFindResponses::new));
+
     }
 }

--- a/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
+++ b/backend/src/main/java/com/ody/notification/service/FcmPushSender.java
@@ -24,10 +24,6 @@ public class FcmPushSender {
     @Transactional
     public void sendGroupMessage(GroupMessage groupMessage, Notification notification) {
         Notification savedNotification = findNotification(notification);
-        if (savedNotification.isStatusDismissed()) {
-            log.info("DISMISSED 상태 푸시 알림 전송 스킵 : {}", notification);
-            return;
-        }
         sendMessage(groupMessage.getMessage());
         updateDepartureReminderToDone(savedNotification);
     }

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -46,6 +46,18 @@ public class NotificationService {
     }
 
     @Transactional
+    public Notification saveAndSchedule(Notification notification) {
+        Notification savedNotification = save(notification);
+        scheduleNotification(savedNotification);
+        return savedNotification;
+    }
+
+    public void scheduleNotification(Notification notification) {
+        scheduleRunner.runWithTransaction(() -> send(notification), notification.getSendAt());
+        log.info("{}에 {} 알림 스케줄링 예약", notification.getSendAt(), notification.getType());
+    }
+
+    @Transactional
     public boolean send(Notification notification) {
         Notification foundNotification = findById(notification.getId());
         if (foundNotification.isStatusDismissed()) {

--- a/backend/src/main/java/com/ody/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/ody/notification/service/NotificationService.java
@@ -52,7 +52,7 @@ public class NotificationService {
         return savedNotification;
     }
 
-    public void scheduleNotification(Notification notification) {
+    private void scheduleNotification(Notification notification) {
         scheduleRunner.runWithTransaction(() -> send(notification), notification.getSendAt());
         log.info("{}에 {} 알림 스케줄링 예약", notification.getSendAt(), notification.getType());
     }

--- a/backend/src/main/java/com/ody/util/ScheduleRunner.java
+++ b/backend/src/main/java/com/ody/util/ScheduleRunner.java
@@ -1,0 +1,33 @@
+package com.ody.util;
+
+import com.ody.common.exception.OdyServerErrorException;
+import com.ody.notification.service.event.PushEvent;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScheduleRunner {
+
+    private final TaskScheduler taskScheduler;
+
+    @Transactional
+    public void runWithTransaction(Runnable runnable, LocalDateTime scheduleTime) {
+        try {
+            Instant startTime = InstantConverter.kstToInstant(scheduleTime);
+            taskScheduler.schedule(() -> {
+                runnable.run();
+                log.info("스케쥴링 로직 실행 성공");
+            }, startTime);
+        }catch (Exception e){
+            log.error("스케쥴링 실패");
+            throw new OdyServerErrorException("스케쥴링에 실패하였습니다");
+        }
+    }
+}

--- a/backend/src/main/java/com/ody/util/ScheduleRunner.java
+++ b/backend/src/main/java/com/ody/util/ScheduleRunner.java
@@ -1,7 +1,6 @@
 package com.ody.util;
 
 import com.ody.common.exception.OdyServerErrorException;
-import com.ody.notification.service.event.PushEvent;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +24,7 @@ public class ScheduleRunner {
                 runnable.run();
                 log.info("스케쥴링 로직 실행 성공");
             }, startTime);
-        }catch (Exception e){
+        } catch (Exception e) {
             log.error("스케쥴링 실패");
             throw new OdyServerErrorException("스케쥴링에 실패하였습니다");
         }

--- a/backend/src/main/resources/db/migration/V13__add_meeting_log_table.sql
+++ b/backend/src/main/resources/db/migration/V13__add_meeting_log_table.sql
@@ -2,8 +2,9 @@ create table if not exists meeting_log (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
     mate_id BIGINT NOT NULL,
     type VARCHAR(50) NOT NULL,
-    created_at TIMESTAMP,
-    updated_at TIMESTAMP,
+    show_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     CONSTRAINT fk_meeting_log_mate
     FOREIGN KEY (mate_id) REFERENCES mate(id)
 );

--- a/backend/src/main/resources/db/migration/V13__add_meeting_log_table.sql
+++ b/backend/src/main/resources/db/migration/V13__add_meeting_log_table.sql
@@ -1,0 +1,9 @@
+create table if not exists meeting_log (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    mate_id BIGINT NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    CONSTRAINT fk_meeting_log_mate
+    FOREIGN KEY (mate_id) REFERENCES mate(id)
+);

--- a/backend/src/test/java/com/ody/common/BaseRepositoryTest.java
+++ b/backend/src/test/java/com/ody/common/BaseRepositoryTest.java
@@ -5,6 +5,7 @@ import com.ody.common.config.JpaAuditingConfig;
 import com.ody.eta.repository.EtaRepository;
 import com.ody.mate.repository.MateRepository;
 import com.ody.meeting.repository.MeetingRepository;
+import com.ody.meetinglog.repository.MeetingLogRepository;
 import com.ody.member.repository.MemberRepository;
 import com.ody.notification.repository.NotificationRepository;
 import com.ody.route.repository.ApiCallRepository;
@@ -42,6 +43,9 @@ public abstract class BaseRepositoryTest {
 
     @Autowired
     protected MemberAppleTokenRepository memberAppleTokenRepository;
+
+    @Autowired
+    protected MeetingLogRepository meetingLogRepository;
 
     @Autowired
     protected EntityManager entityManager;

--- a/backend/src/test/java/com/ody/common/FixtureGenerator.java
+++ b/backend/src/test/java/com/ody/common/FixtureGenerator.java
@@ -11,6 +11,9 @@ import com.ody.mate.repository.MateRepository;
 import com.ody.meeting.domain.Location;
 import com.ody.meeting.domain.Meeting;
 import com.ody.meeting.repository.MeetingRepository;
+import com.ody.meetinglog.domain.MeetingLog;
+import com.ody.meetinglog.domain.MeetingLogType;
+import com.ody.meetinglog.repository.MeetingLogRepository;
 import com.ody.member.domain.AuthProvider;
 import com.ody.member.domain.DeviceToken;
 import com.ody.member.domain.Member;
@@ -40,6 +43,7 @@ public class FixtureGenerator {
     private final EtaRepository etaRepository;
     private final ApiCallRepository apiCallRepository;
     private final MemberAppleTokenRepository memberAppleTokenRepository;
+    private final MeetingLogRepository meetingLogRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     public FixtureGenerator(
@@ -50,6 +54,7 @@ public class FixtureGenerator {
             EtaRepository etaRepository,
             ApiCallRepository apiCallRepository,
             MemberAppleTokenRepository memberAppleTokenRepository,
+            MeetingLogRepository meetingLogRepository,
             JwtTokenProvider jwtTokenProvider
     ) {
         this.meetingRepository = meetingRepository;
@@ -59,6 +64,7 @@ public class FixtureGenerator {
         this.etaRepository = etaRepository;
         this.apiCallRepository = apiCallRepository;
         this.memberAppleTokenRepository = memberAppleTokenRepository;
+        this.meetingLogRepository = meetingLogRepository;
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
@@ -209,6 +215,11 @@ public class FixtureGenerator {
 
     public ApiCall generateApiCall(ClientType clientType, int count, LocalDate date) {
         return apiCallRepository.save(new ApiCall(clientType, count, date));
+    }
+
+    public MeetingLog generateMeetingLog(Mate mate, MeetingLogType type, LocalDateTime showAt) {
+        MeetingLog meetingLog = new MeetingLog(mate, type, showAt);
+        return meetingLogRepository.save(meetingLog);
     }
 
     @Transactional

--- a/backend/src/test/java/com/ody/common/FixtureGeneratorConfig.java
+++ b/backend/src/test/java/com/ody/common/FixtureGeneratorConfig.java
@@ -27,7 +27,8 @@ public class FixtureGeneratorConfig {
             ApiCallRepository apiCallRepository,
             MemberAppleTokenRepository memberAppleTokenRepository,
             MeetingLogRepository meetingLogRepository,
-            JwtTokenProvider jwtTokenProvider) {
+            JwtTokenProvider jwtTokenProvider
+    ) {
         return new FixtureGenerator(
                 meetingRepository,
                 memberRepository,

--- a/backend/src/test/java/com/ody/common/FixtureGeneratorConfig.java
+++ b/backend/src/test/java/com/ody/common/FixtureGeneratorConfig.java
@@ -5,6 +5,7 @@ import com.ody.auth.repository.MemberAppleTokenRepository;
 import com.ody.eta.repository.EtaRepository;
 import com.ody.mate.repository.MateRepository;
 import com.ody.meeting.repository.MeetingRepository;
+import com.ody.meetinglog.repository.MeetingLogRepository;
 import com.ody.member.repository.MemberRepository;
 import com.ody.notification.repository.NotificationRepository;
 import com.ody.route.repository.ApiCallRepository;
@@ -25,8 +26,8 @@ public class FixtureGeneratorConfig {
             EtaRepository etaRepository,
             ApiCallRepository apiCallRepository,
             MemberAppleTokenRepository memberAppleTokenRepository,
-            JwtTokenProvider jwtTokenProvider
-    ) {
+            MeetingLogRepository meetingLogRepository,
+            JwtTokenProvider jwtTokenProvider) {
         return new FixtureGenerator(
                 meetingRepository,
                 memberRepository,
@@ -35,6 +36,7 @@ public class FixtureGeneratorConfig {
                 etaRepository,
                 apiCallRepository,
                 memberAppleTokenRepository,
+                meetingLogRepository,
                 jwtTokenProvider
         );
     }

--- a/backend/src/test/java/com/ody/eta/service/EtaSchedulingServiceTest.java
+++ b/backend/src/test/java/com/ody/eta/service/EtaSchedulingServiceTest.java
@@ -188,7 +188,7 @@ class EtaSchedulingServiceTest extends BaseServiceTest {
                         verify(noticeService).send(any(EtaSchedulingNotice.class), any(GroupMessage.class));
                     }),
                     dynamicTest("TTL 만료 전에 ETA api 요청이 안 오면, 스케줄링 알림이 재전송된다.", () -> {
-                        Thread.sleep(ttlMs + 200);
+                        Thread.sleep(ttlMs + 500);
                         verify(noticeService).send(any(EtaSchedulingNotice.class), any(DirectMessage.class));
                     })
             );

--- a/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
+++ b/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
@@ -80,7 +80,9 @@ class MateServiceTest extends BaseServiceTest {
             NudgeRequest nudgeRequest = new NudgeRequest(requestMate.getId(), nudgedLateWarningMate.getId());
             mateService.nudge(nudgeRequest);
 
-            List<MeetingLog> meetingLogs = meetingLogRepository.findByMeetingId(oneMinuteLaterMeeting.getId());
+            List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(
+                    oneMinuteLaterMeeting.getId(), LocalDateTime.now()
+            );
 
             assertAll(
                     () -> assertThat(meetingLogs).hasSize(1),
@@ -207,7 +209,9 @@ class MateServiceTest extends BaseServiceTest {
             MateSaveRequestV2 mateSaveRequest = dtoGenerator.generateMateSaveRequest(laterMeeting);
             mateService.saveAndSendNotifications(mateSaveRequest, member, laterMeeting);
 
-            List<MeetingLog> meetingLogs = meetingLogRepository.findByMeetingId(laterMeeting.getId());
+            List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(
+                    laterMeeting.getId(), LocalDateTime.now()
+            );
 
             assertAll(
                     () -> assertThat(meetingLogs).hasSize(1),
@@ -226,7 +230,7 @@ class MateServiceTest extends BaseServiceTest {
 
             Thread.sleep(1000L); //스케쥴링 로직 실행을 위한 pause
 
-            List<MeetingLogType> meetingLogTypes = meetingLogRepository.findByMeetingId(now.getId())
+            List<MeetingLogType> meetingLogTypes = meetingLogRepository.findMeetingLogsBeforeThanEqual(now.getId(), LocalDateTime.now())
                     .stream()
                     .map(MeetingLog::getType)
                     .toList();
@@ -280,7 +284,7 @@ class MateServiceTest extends BaseServiceTest {
 
         mateService.withdraw(mate);
 
-        List<MeetingLog> meetingLogs = meetingLogRepository.findByMeetingId(meeting.getId());
+        List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meeting.getId(), LocalDateTime.now());
 
         assertAll(
                 () -> assertThat(meetingLogs).hasSize(1),
@@ -346,7 +350,7 @@ class MateServiceTest extends BaseServiceTest {
 
         mateService.leaveByMeetingIdAndMemberId(meeting.getId(), kaki.getId());
 
-        List<MeetingLog> meetingLogs = meetingLogRepository.findByMeetingId(meeting.getId());
+        List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meeting.getId(), LocalDateTime.now());
 
         assertAll(
                 () -> assertThat(meetingLogs).hasSize(1),

--- a/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
+++ b/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
@@ -14,6 +14,9 @@ import com.ody.mate.dto.request.MateSaveRequestV2;
 import com.ody.mate.dto.request.NudgeRequest;
 import com.ody.mate.dto.response.MateSaveResponseV2;
 import com.ody.meeting.domain.Meeting;
+import com.ody.meetinglog.domain.MeetingLog;
+import com.ody.meetinglog.domain.MeetingLogType;
+import com.ody.meetinglog.repository.MeetingLogRepository;
 import com.ody.member.domain.DeviceToken;
 import com.ody.member.domain.Member;
 import com.ody.notification.domain.FcmTopic;
@@ -30,6 +33,9 @@ class MateServiceTest extends BaseServiceTest {
 
     @Autowired
     private MateService mateService;
+
+    @Autowired
+    private MeetingLogRepository meetingLogRepository;
 
     @DisplayName("회원이 참여하고 있는 특정 약속의 참여자 리스트를 조회한다.")
     @Test
@@ -62,6 +68,25 @@ class MateServiceTest extends BaseServiceTest {
     @DisplayName("재촉하기 테스트")
     @Nested
     class NudgeTest {
+
+        @DisplayName("약속 재촉에 성공하면 재촉 로그가 남는다")
+        @Test
+        void saveNudgeLogWhenNudgeSuccess() {
+            Meeting oneMinuteLaterMeeting = fixtureGenerator.generateMeeting(LocalDateTime.now().plusMinutes(1L));
+            Mate requestMate = fixtureGenerator.generateMate(oneMinuteLaterMeeting);
+            Mate nudgedLateWarningMate = fixtureGenerator.generateMate(oneMinuteLaterMeeting);
+            Eta lateWarningEta = fixtureGenerator.generateEta(nudgedLateWarningMate, 2L);
+
+            NudgeRequest nudgeRequest = new NudgeRequest(requestMate.getId(), nudgedLateWarningMate.getId());
+            mateService.nudge(nudgeRequest);
+
+            List<MeetingLog> meetingLogs = meetingLogRepository.findByMeetingId(oneMinuteLaterMeeting.getId());
+
+            assertAll(
+                    () -> assertThat(meetingLogs).hasSize(1),
+                    () -> assertThat(meetingLogs.get(0).getType()).isEqualTo(MeetingLogType.NUDGE_LOG)
+            );
+        }
 
         @DisplayName("약속이 1분 뒤이고 소요시간이 2분으로 Eta상태가 지각 위기인 mate를 재촉할 수 있다")
         @Test
@@ -173,6 +198,45 @@ class MateServiceTest extends BaseServiceTest {
     @Nested
     class saveAndSendNotifications {
 
+        @DisplayName("나중에 출발해야 할 때 : 입장 로그가 남는다")
+        @Test
+        void saveEntryLogWhenLateDeparture() {
+            Member member = fixtureGenerator.generateMember();
+            Meeting laterMeeting = fixtureGenerator.generateMeeting(LocalDateTime.now().plusHours(1L));
+
+            MateSaveRequestV2 mateSaveRequest = dtoGenerator.generateMateSaveRequest(laterMeeting);
+            mateService.saveAndSendNotifications(mateSaveRequest, member, laterMeeting);
+
+            List<MeetingLog> meetingLogs = meetingLogRepository.findByMeetingId(laterMeeting.getId());
+
+            assertAll(
+                    () -> assertThat(meetingLogs).hasSize(1),
+                    () -> assertThat(meetingLogs.get(0).getType()).isEqualTo(MeetingLogType.ENTRY_LOG)
+            );
+        }
+
+        @DisplayName("당장 출발해야 할 때 : 입장 로그 + 출발 알림 로그가 남는다")
+        @Test
+        void saveEntryAndDepartureReminderLogWhenNowDeparture() throws InterruptedException {
+            Member member = fixtureGenerator.generateMember();
+            Meeting now = fixtureGenerator.generateMeeting(LocalDateTime.now());
+            MateSaveRequestV2 mateSaveRequest = dtoGenerator.generateMateSaveRequest(now);
+
+            mateService.saveAndSendNotifications(mateSaveRequest, member, now);
+
+            Thread.sleep(100L); //스케쥴링 로직 실행을 위한 pause
+
+            List<MeetingLogType> meetingLogTypes = meetingLogRepository.findByMeetingId(now.getId())
+                    .stream()
+                    .map(MeetingLog::getType)
+                    .toList();
+
+            assertAll(
+                    () -> assertThat(meetingLogTypes).hasSize(2),
+                    () -> assertThat(meetingLogTypes).containsExactly(MeetingLogType.ENTRY_LOG, MeetingLogType.DEPARTURE_REMINDER)
+            );
+        }
+
         @DisplayName("하나의 약속에 동일한 닉네임을 가진 참여자가 존재할 수 있다.")
         @Test
         void saveMateWithDuplicateNickname() {
@@ -204,6 +268,24 @@ class MateServiceTest extends BaseServiceTest {
             assertThatThrownBy(() -> mateService.saveAndSendNotifications(mateSaveRequest, member, meeting))
                     .isInstanceOf(OdyBadRequestException.class);
         }
+    }
+
+    @DisplayName("참여자 삭제 시, 삭제 로그가 남는다")
+    @Test
+    void saveMemberDeleteLogWhenDeleteMate() {
+        Meeting meeting = fixtureGenerator.generateMeeting();
+        Mate mate = fixtureGenerator.generateMate(meeting);
+        FcmTopic fcmTopic = new FcmTopic(meeting);
+        DeviceToken deviceToken = mate.getMember().getDeviceToken();
+
+        mateService.withdraw(mate);
+
+        List<MeetingLog> meetingLogs = meetingLogRepository.findByMeetingId(meeting.getId());
+
+        assertAll(
+                () -> assertThat(meetingLogs).hasSize(1),
+                () -> assertThat(meetingLogs.get(0).getType()).isEqualTo(MeetingLogType.MEMBER_DELETION_LOG)
+        );
     }
 
     @DisplayName("참여자 삭제 시, 구독하고 있는 fcmTopic 취소힌다.")
@@ -253,5 +335,22 @@ class MateServiceTest extends BaseServiceTest {
 
         assertThatThrownBy(() -> mateService.findAllByMeetingIdIfMate(kaki, meeting.getId()))
                 .isInstanceOf(OdyNotFoundException.class);
+    }
+
+    @DisplayName("방을 나갔다면 방 나가기 로그가 남는다")
+    @Test
+    void saveLeaveLogWhenMateLeave() {
+        Meeting meeting = fixtureGenerator.generateMeeting();
+        Member kaki = fixtureGenerator.generateMember("kaki");
+        fixtureGenerator.generateMate(meeting, kaki);
+
+        mateService.leaveByMeetingIdAndMemberId(meeting.getId(), kaki.getId());
+
+        List<MeetingLog> meetingLogs = meetingLogRepository.findByMeetingId(meeting.getId());
+
+        assertAll(
+                () -> assertThat(meetingLogs).hasSize(1),
+                () -> assertThat(meetingLogs.get(0).getType()).isEqualTo(MeetingLogType.LEAVE_LOG)
+        );
     }
 }

--- a/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
+++ b/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
@@ -80,7 +80,7 @@ class MateServiceTest extends BaseServiceTest {
             NudgeRequest nudgeRequest = new NudgeRequest(requestMate.getId(), nudgedLateWarningMate.getId());
             mateService.nudge(nudgeRequest);
 
-            List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(
+            List<MeetingLog> meetingLogs = meetingLogRepository.findByShowAtBeforeOrEqualTo(
                     oneMinuteLaterMeeting.getId(), LocalDateTime.now()
             );
 
@@ -209,7 +209,7 @@ class MateServiceTest extends BaseServiceTest {
             MateSaveRequestV2 mateSaveRequest = dtoGenerator.generateMateSaveRequest(laterMeeting);
             mateService.saveAndSendNotifications(mateSaveRequest, member, laterMeeting);
 
-            List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(
+            List<MeetingLog> meetingLogs = meetingLogRepository.findByShowAtBeforeOrEqualTo(
                     laterMeeting.getId(), LocalDateTime.now()
             );
 
@@ -228,7 +228,7 @@ class MateServiceTest extends BaseServiceTest {
 
             mateService.saveAndSendNotifications(mateSaveRequest, member, now);
 
-            List<MeetingLogType> meetingLogTypes = meetingLogRepository.findMeetingLogsBeforeThanEqual(now.getId(), LocalDateTime.now())
+            List<MeetingLogType> meetingLogTypes = meetingLogRepository.findByShowAtBeforeOrEqualTo(now.getId(), LocalDateTime.now())
                     .stream()
                     .map(MeetingLog::getType)
                     .toList();
@@ -282,7 +282,7 @@ class MateServiceTest extends BaseServiceTest {
 
         mateService.withdraw(mate);
 
-        List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meeting.getId(), LocalDateTime.now());
+        List<MeetingLog> meetingLogs = meetingLogRepository.findByShowAtBeforeOrEqualTo(meeting.getId(), LocalDateTime.now());
 
         assertAll(
                 () -> assertThat(meetingLogs).hasSize(1),
@@ -348,7 +348,7 @@ class MateServiceTest extends BaseServiceTest {
 
         mateService.leaveByMeetingIdAndMemberId(meeting.getId(), kaki.getId());
 
-        List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meeting.getId(), LocalDateTime.now());
+        List<MeetingLog> meetingLogs = meetingLogRepository.findByShowAtBeforeOrEqualTo(meeting.getId(), LocalDateTime.now());
 
         assertAll(
                 () -> assertThat(meetingLogs).hasSize(1),

--- a/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
+++ b/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
@@ -228,8 +228,6 @@ class MateServiceTest extends BaseServiceTest {
 
             mateService.saveAndSendNotifications(mateSaveRequest, member, now);
 
-            Thread.sleep(1000L); //스케쥴링 로직 실행을 위한 pause
-
             List<MeetingLogType> meetingLogTypes = meetingLogRepository.findMeetingLogsBeforeThanEqual(now.getId(), LocalDateTime.now())
                     .stream()
                     .map(MeetingLog::getType)

--- a/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
+++ b/backend/src/test/java/com/ody/mate/service/MateServiceTest.java
@@ -224,7 +224,7 @@ class MateServiceTest extends BaseServiceTest {
 
             mateService.saveAndSendNotifications(mateSaveRequest, member, now);
 
-            Thread.sleep(100L); //스케쥴링 로직 실행을 위한 pause
+            Thread.sleep(1000L); //스케쥴링 로직 실행을 위한 pause
 
             List<MeetingLogType> meetingLogTypes = meetingLogRepository.findByMeetingId(now.getId())
                     .stream()

--- a/backend/src/test/java/com/ody/meetinglog/repository/MeetingLogRepositoryTest.java
+++ b/backend/src/test/java/com/ody/meetinglog/repository/MeetingLogRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.ody.meetinglog.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.ody.common.BaseRepositoryTest;
+import com.ody.mate.domain.Mate;
+import com.ody.meeting.domain.Meeting;
+import com.ody.meetinglog.domain.MeetingLog;
+import com.ody.meetinglog.domain.MeetingLogType;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MeetingLogRepositoryTest extends BaseRepositoryTest {
+
+    @DisplayName("특정 시간 이전의 약속 로그를 가져온다")
+    @Test
+    void findMeetingLogsBeforeThanEqual() {
+        LocalDateTime now = LocalDateTime.now();
+        Meeting meeting = fixtureGenerator.generateMeeting();
+        Mate mate = fixtureGenerator.generateMate(meeting);
+        fixtureGenerator.generateMeetingLog(mate, MeetingLogType.ENTRY_LOG, now);
+        fixtureGenerator.generateMeetingLog(mate, MeetingLogType.DEPARTURE_REMINDER, now.plusMinutes(1L));
+
+        List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meeting.getId(), now);
+
+        assertAll(
+                () -> assertThat(meetingLogs).hasSize(1),
+                () -> assertThat(meetingLogs.get(0).getType()).isEqualTo(MeetingLogType.ENTRY_LOG)
+        );
+    }
+}

--- a/backend/src/test/java/com/ody/meetinglog/repository/MeetingLogRepositoryTest.java
+++ b/backend/src/test/java/com/ody/meetinglog/repository/MeetingLogRepositoryTest.java
@@ -17,14 +17,14 @@ class MeetingLogRepositoryTest extends BaseRepositoryTest {
 
     @DisplayName("특정 시간 이전의 약속 로그를 가져온다")
     @Test
-    void findMeetingLogsBeforeThanEqual() {
+    void findByShowAtBeforeOrEqualTo() {
         LocalDateTime now = LocalDateTime.now();
         Meeting meeting = fixtureGenerator.generateMeeting();
         Mate mate = fixtureGenerator.generateMate(meeting);
         fixtureGenerator.generateMeetingLog(mate, MeetingLogType.ENTRY_LOG, now);
         fixtureGenerator.generateMeetingLog(mate, MeetingLogType.DEPARTURE_REMINDER, now.plusSeconds(1L));
 
-        List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meeting.getId(), now);
+        List<MeetingLog> meetingLogs = meetingLogRepository.findByShowAtBeforeOrEqualTo(meeting.getId(), now);
 
         assertAll(
                 () -> assertThat(meetingLogs).hasSize(1),

--- a/backend/src/test/java/com/ody/meetinglog/repository/MeetingLogRepositoryTest.java
+++ b/backend/src/test/java/com/ody/meetinglog/repository/MeetingLogRepositoryTest.java
@@ -22,7 +22,7 @@ class MeetingLogRepositoryTest extends BaseRepositoryTest {
         Meeting meeting = fixtureGenerator.generateMeeting();
         Mate mate = fixtureGenerator.generateMate(meeting);
         fixtureGenerator.generateMeetingLog(mate, MeetingLogType.ENTRY_LOG, now);
-        fixtureGenerator.generateMeetingLog(mate, MeetingLogType.DEPARTURE_REMINDER, now.plusMinutes(1L));
+        fixtureGenerator.generateMeetingLog(mate, MeetingLogType.DEPARTURE_REMINDER, now.plusSeconds(1L));
 
         List<MeetingLog> meetingLogs = meetingLogRepository.findMeetingLogsBeforeThanEqual(meeting.getId(), now);
 

--- a/backend/src/test/java/com/ody/notification/service/FcmPushSenderTest.java
+++ b/backend/src/test/java/com/ody/notification/service/FcmPushSenderTest.java
@@ -43,24 +43,4 @@ class FcmPushSenderTest extends BaseServiceTest {
                 () -> assertThat(notificationAfterSend.getStatus()).isEqualTo(NotificationStatus.DONE)
         );
     }
-
-    @DisplayName("DISMISSED 상태이면 푸시 알림을 보내지 않는다.")
-    @Test
-    void sendPushNotificationFailure() {
-        Message message = Mockito.mock(Message.class);
-        GroupMessage groupMessage = new GroupMessage(message);
-        Notification dismissedNotification = fixtureGenerator.generateNotification(
-                NotificationType.DEPARTURE_REMINDER,
-                NotificationStatus.DISMISSED
-        );
-
-        fcmPushSender.sendGroupMessage(groupMessage, dismissedNotification);
-
-        Notification notificationAfterSend = notificationRepository.findById(dismissedNotification.getId()).get();
-
-        assertAll(
-                () -> Mockito.verifyNoInteractions(firebaseMessaging),
-                () -> assertThat(notificationAfterSend.getStatus()).isEqualTo(NotificationStatus.DISMISSED)
-        );
-    }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #981 


<br>

# 📝 작업 내용
- 도메인 분리 5단계 중 1단계인 MeetingLog 도메인을 추가합니다.
**- 1단계 : MeetingLog 도메인을 추가한다.**
2단계 : ETA_SCHEDULING_NOTICE 를 trigger 도메인으로 분리한다.
3단계 : Notification과 ReservedNotification 도메인으로 분리한다.
4단계 : Dev와 Prod 환경의 data를 마이그레이션한다.
5단계 : 3-4단계 리팩터링 내역을 merge 한다

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
- 개인적으로 notificationService에서 send 이후에 update를 하면 fcmPushSender에 있는 update 로직을 제거할 수 있어서 그렇게 하고 싶은데, 비동기로 이벤트 수신 후, 에러가 발생하는 경우에 대응하지 못해요. 제리는 어떻게 생각하나요?

