### PR TITLE
fix: 애플 로그인 AppleRefreshToken 널 값 에러 해결

### DIFF
--- a/backend/src/main/java/com/ody/auth/dto/response/AppleAuthValidationResponse.java
+++ b/backend/src/main/java/com/ody/auth/dto/response/AppleAuthValidationResponse.java
@@ -1,10 +1,22 @@
 package com.ody.auth.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record AppleAuthValidationResponse(
+
+        @JsonProperty("access_token")
         String accessToken,
+
+        @JsonProperty("token_type")
         String tokenType,
-        String expiresIn,
+
+        @JsonProperty("expires_in")
+        int expiresIn,
+
+        @JsonProperty("refresh_token")
         String refreshToken,
+
+        @JsonProperty("id_token")
         String idToken
 ) {
 

--- a/backend/src/main/java/com/ody/auth/dto/response/AppleAuthValidationResponse.java
+++ b/backend/src/main/java/com/ody/auth/dto/response/AppleAuthValidationResponse.java
@@ -1,22 +1,16 @@
 package com.ody.auth.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record AppleAuthValidationResponse(
 
-        @JsonProperty("access_token")
         String accessToken,
-
-        @JsonProperty("token_type")
         String tokenType,
-
-        @JsonProperty("expires_in")
         int expiresIn,
-
-        @JsonProperty("refresh_token")
         String refreshToken,
-
-        @JsonProperty("id_token")
         String idToken
 ) {
 

--- a/backend/src/test/java/com/ody/auth/dto/response/AppleAuthValidationResponseTest.java
+++ b/backend/src/test/java/com/ody/auth/dto/response/AppleAuthValidationResponseTest.java
@@ -1,0 +1,30 @@
+package com.ody.auth.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AppleAuthValidationResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @DisplayName("Apple JSON 응답을 AppleAuthValidationResponse로 매핑한다.")
+    @Test
+    void shouldMapJsonToAppleAuthValidationResponse() throws Exception {
+        String response = """
+                {
+                  "access_token": "adg61...67Or9",
+                  "token_type": "Bearer",
+                  "expires_in": 3600,
+                  "refresh_token": "rca7...lABoQ",
+                  "id_token": "eyJra...96sZg"
+                }
+                """;
+
+        AppleAuthValidationResponse result = objectMapper.readValue(response, AppleAuthValidationResponse.class);
+
+        assertThat(result.refreshToken()).isEqualTo("rca7...lABoQ");
+    }
+}


### PR DESCRIPTION
# 🚩 연관 이슈 
close #994


<br>

# 📝 작업 내용

발생한 에러:

```
jakarta.validation.ConstraintViolationException: Validation failed for classes [com.ody.auth.domain.MemberAppleToken] during persist time for groups [jakarta.validation.groups.Default, ]
List of constraint violations:[
	ConstraintViolationImpl{interpolatedMessage='널이어서는 안됩니다', propertyPath=appleRefreshToken, rootBeanClass=class com.ody.auth.domain.MemberAppleToken, messageTemplate='{jakarta.validation.constraints.NotNull.message}'}
```

원인:
Apple에서 제공하는 JSON 형식과 맞지 않아 refreshToken 필드에 널 값이 들어감
이후 MemberAppleToken을 저장하려는 과정에서 appleRefreshToken의 NotNull 조건에 부합하지 않아 에러 발생함


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
