### PR TITLE
refactor: sdk 버전 변경 및 포그라운드 서비스 type 수정

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,12 +18,12 @@ properties.load(project.rootProject.file("local.properties").inputStream())
 
 android {
     namespace = "com.mulberry.ody"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.mulberry.ody"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 14
         versionName = "1.1.1"
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,9 +14,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
-    <uses-permission
-        android:name="com.google.android.gms.permission.AD_ID"
-        tools:node="remove" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
 
     <meta-data
         android:name="google_analytics_adid_collection_enabled"
@@ -126,7 +125,7 @@
         <service
             android:name=".data.local.service.EtaDashboardService"
             android:exported="false"
-            android:foregroundServiceType="location" />
+            android:foregroundServiceType="location|dataSync" />
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
@@ -5,7 +5,10 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.IBinder
+import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import com.mulberry.ody.domain.apiresult.fold
 import com.mulberry.ody.domain.apiresult.getOrNull
@@ -81,6 +84,7 @@ class EtaDashboardService : Service() {
                 }
 
                 if (!meetingJobs.contains(meetingId)) {
+                    startForeground(meetingId)
                     openEtaDashboard(meetingId, meetingTime)
                 }
             }
@@ -92,13 +96,24 @@ class EtaDashboardService : Service() {
         return START_REDELIVER_INTENT
     }
 
+    private fun startForeground(meetingId: Long) {
+        val notification = etaDashboardNotification.createNotification(meetingId)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ServiceCompat.startForeground(
+                this,
+                meetingId.toInt(),
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION or ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            startForeground(meetingId.toInt(), notification)
+        }
+    }
+
     private fun openEtaDashboard(
         meetingId: Long,
         meetingTime: Long,
     ) {
-        val notification = etaDashboardNotification.createNotification(meetingId)
-        startForeground(meetingId.toInt(), notification)
-
         val job =
             serviceScope.launch {
                 while (isInETARange(meetingTime)) {

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
@@ -1,9 +1,12 @@
 package com.mulberry.ody.data.local.service
 
+import android.Manifest
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.IBinder
+import androidx.core.content.ContextCompat
 import com.mulberry.ody.domain.apiresult.fold
 import com.mulberry.ody.domain.apiresult.getOrNull
 import com.mulberry.ody.domain.apiresult.onNetworkError
@@ -42,6 +45,22 @@ class EtaDashboardService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? {
         return null
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        val requiredPermissions = arrayOf(
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        )
+
+        if (requiredPermissions.all {
+                ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_DENIED
+            }) {
+            stopSelf()
+            return
+        }
     }
 
     override fun onStartCommand(

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
@@ -53,14 +53,16 @@ class EtaDashboardService : Service() {
     override fun onCreate() {
         super.onCreate()
 
-        val requiredPermissions = arrayOf(
-            Manifest.permission.ACCESS_COARSE_LOCATION,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-        )
+        val requiredPermissions =
+            arrayOf(
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+            )
 
         if (requiredPermissions.all {
                 ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_DENIED
-            }) {
+            }
+        ) {
             stopSelf()
             return
         }

--- a/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
+++ b/android/app/src/main/java/com/mulberry/ody/data/local/service/EtaDashboardService.kt
@@ -86,7 +86,7 @@ class EtaDashboardService : Service() {
                 }
 
                 if (!meetingJobs.contains(meetingId)) {
-                    startForeground(meetingId)
+                    initializeForeground(meetingId)
                     openEtaDashboard(meetingId, meetingTime)
                 }
             }
@@ -98,7 +98,7 @@ class EtaDashboardService : Service() {
         return START_REDELIVER_INTENT
     }
 
-    private fun startForeground(meetingId: Long) {
+    private fun initializeForeground(meetingId: Long) {
         val notification = etaDashboardNotification.createNotification(meetingId)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             ServiceCompat.startForeground(


### PR DESCRIPTION
# 🚩 연관 이슈 
close #1028


<br>

# 📝 작업 내용
- [x] targetSdkVersion 35로 수정
- [x] type에 syncData 추가 및 관련 권한 추가
- [x] 런타임에 foreground service type 추가
- [x] 권한 설정되지 않았을 시 foreground service 시작하지 않는 코드 추가


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
fcm 우선순위 변경한 거 관련해서 수정사항 있으면 적용하려했는데 안드로이드 쪽에서 수정할만한 건 없었어요!!
[foreground service type](https://developer.android.com/about/versions/14/changes/fgs-types-required?hl=ko#location) 쪽 수정할게 있어서 그 부분 수정하면서 sdk 버전도 올렸습니다
