### PR TITLE
fix: 정상배포를 위한 테스트 타임존 설정

### DIFF
--- a/backend/src/test/java/com/ody/common/BaseRepositoryTest.java
+++ b/backend/src/test/java/com/ody/common/BaseRepositoryTest.java
@@ -10,6 +10,8 @@ import com.ody.member.repository.MemberRepository;
 import com.ody.notification.repository.NotificationRepository;
 import com.ody.route.repository.ApiCallRepository;
 import jakarta.persistence.EntityManager;
+import java.util.TimeZone;
+import org.junit.jupiter.api.BeforeAll;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -49,4 +51,10 @@ public abstract class BaseRepositoryTest {
 
     @Autowired
     protected EntityManager entityManager;
+
+    @BeforeAll
+    static void setUp() {
+        TimeZone seoulTimeZone = TimeZone.getTimeZone("Asia/Seoul");
+        TimeZone.setDefault(seoulTimeZone);
+    }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #1044


<br>

# 📝 작업 내용
- CI를 도는 환경은 github가 빌려준 미국 서버 기준이기에 타임존에 따라 쿼리 에러가 발생
- 따라서 default timezone을 서울로 설정함으로써 CI에서 에러가 나지 않도록 수정
- 이걸해야 정상배포가 가능함!

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
