### PR TITLE
feat: 빈 이미지 URL이면 기본 프로필 이미지 제공

### DIFF
--- a/backend/src/main/java/com/ody/auth/dto/request/SocialAuthRequest.java
+++ b/backend/src/main/java/com/ody/auth/dto/request/SocialAuthRequest.java
@@ -8,6 +8,7 @@ import com.ody.member.domain.ProviderType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class SocialAuthRequest {
+
+    private static final String DEFAULT_IMAGE_URL = "https://img1.kakaocdn.net/thumb/R110x110.q70/?fname=https://t1.kakaocdn.net/account_images/default_profile.jpeg";
 
     @Schema(description = "디바이스 토큰", example = "devicetokendevicetoken")
     @NotBlank
@@ -33,6 +36,9 @@ public abstract class SocialAuthRequest {
 
     protected Member toMember(ProviderType providerType) {
         AuthProvider authProvider = new AuthProvider(providerType, providerId);
-        return new Member(authProvider, new Nickname(nickname), imageUrl, new DeviceToken(deviceToken));
+        String finalImageUrl = Optional.ofNullable(imageUrl)
+                .filter(s -> !s.isBlank())
+                .orElse(DEFAULT_IMAGE_URL);
+        return new Member(authProvider, new Nickname(nickname), finalImageUrl, new DeviceToken(deviceToken));
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈 
close #1062


<br>

# 📝 작업 내용

IOS에서 빈 이미지 URL로 회원 생성을 시도하면 이를 기본 프로필 이미지로 대체합니다.
IOS 요청 시 빈 이미지 URL을 제공해 프로필 이미지가 깨져보이는 문제를 해결합니다.

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
