### PR TITLE
[FIX] 회원 재탈퇴 에러 픽스

### DIFF
--- a/backend/src/main/java/com/ody/auth/service/MemberAppleTokenService.java
+++ b/backend/src/main/java/com/ody/auth/service/MemberAppleTokenService.java
@@ -24,12 +24,6 @@ public class MemberAppleTokenService {
                 .orElseGet(() -> memberAppleTokenRepository.save(new MemberAppleToken(member, appleRefreshToken)));
     }
 
-    public String findAppleRefreshToken(AuthProvider authProvider) {
-        return memberAppleTokenRepository.findByMember_AuthProvider(authProvider)
-                .map(MemberAppleToken::getAppleRefreshToken)
-                .orElseThrow(() -> new OdyNotFoundException("AppleRefreshToken을 찾을 수 없습니다."));
-    }
-
     public MemberAppleToken findByMemberId(long memberId) {
         return memberAppleTokenRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new OdyNotFoundException("AppleRefreshToken을 찾을 수 없습니다."));

--- a/backend/src/main/java/com/ody/auth/service/MemberAppleTokenService.java
+++ b/backend/src/main/java/com/ody/auth/service/MemberAppleTokenService.java
@@ -30,6 +30,11 @@ public class MemberAppleTokenService {
                 .orElseThrow(() -> new OdyNotFoundException("AppleRefreshToken을 찾을 수 없습니다."));
     }
 
+    public MemberAppleToken findByMemberId(long memberId) {
+        return memberAppleTokenRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new OdyNotFoundException("AppleRefreshToken을 찾을 수 없습니다."));
+    }
+
     @Transactional
     public void delete(AuthProvider authProvider) {
         memberAppleTokenRepository.deleteByMember_AuthProvider(authProvider);

--- a/backend/src/main/java/com/ody/auth/service/SocialAuthUnlinkClient.java
+++ b/backend/src/main/java/com/ody/auth/service/SocialAuthUnlinkClient.java
@@ -1,10 +1,11 @@
 package com.ody.auth.service;
 
+import com.ody.member.domain.Member;
 import com.ody.member.domain.ProviderType;
 
 public interface SocialAuthUnlinkClient {
 
-    void unlink(String providerId);
+    void unlink(Member member);
 
     ProviderType getProviderType();
 }

--- a/backend/src/main/java/com/ody/auth/service/apple/AppleRevokeTokenClient.java
+++ b/backend/src/main/java/com/ody/auth/service/apple/AppleRevokeTokenClient.java
@@ -1,10 +1,12 @@
 package com.ody.auth.service.apple;
 
 import com.ody.auth.config.AppleProperties;
+import com.ody.auth.domain.MemberAppleToken;
 import com.ody.auth.service.MemberAppleTokenService;
 import com.ody.auth.service.SocialAuthUnlinkClient;
 import com.ody.common.exception.OdyServerErrorException;
 import com.ody.member.domain.AuthProvider;
+import com.ody.member.domain.Member;
 import com.ody.member.domain.ProviderType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,13 +31,13 @@ public class AppleRevokeTokenClient implements SocialAuthUnlinkClient {
     private final AppleClientSecretGenerator appleClientSecretGenerator;
 
     @Override
-    public void unlink(String providerId) {
+    public void unlink(Member member) {
         String clientSecret = appleClientSecretGenerator.generate();
 
-        AuthProvider authProvider = new AuthProvider(ProviderType.APPLE, providerId);
-        String appleRefreshToken = memberAppleTokenService.findAppleRefreshToken(authProvider);
+        AuthProvider authProvider = new AuthProvider(ProviderType.APPLE, member.getAuthProvider().getProviderId());
+        MemberAppleToken appleRefreshToken = memberAppleTokenService.findByMemberId(member.getId());
 
-        revokeToken(clientSecret, authProvider, appleRefreshToken);
+        revokeToken(clientSecret, authProvider, appleRefreshToken.getAppleRefreshToken());
     }
 
     private void revokeToken(String clientSecret, AuthProvider authProvider, String appleRefreshToken) {

--- a/backend/src/main/java/com/ody/auth/service/kakao/KakaoAuthUnlinkClient.java
+++ b/backend/src/main/java/com/ody/auth/service/kakao/KakaoAuthUnlinkClient.java
@@ -4,6 +4,7 @@ import com.google.common.net.HttpHeaders;
 import com.ody.auth.config.KakaoProperties;
 import com.ody.auth.service.SocialAuthUnlinkClient;
 import com.ody.common.exception.OdyBadRequestException;
+import com.ody.member.domain.Member;
 import com.ody.member.domain.ProviderType;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -34,10 +35,10 @@ public class KakaoAuthUnlinkClient implements SocialAuthUnlinkClient {
     }
 
     @Override
-    public void unlink(String providerId) {
+    public void unlink(Member member) {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("target_id_type", "user_id");
-        body.add("target_id", providerId);
+        body.add("target_id", member.getAuthProvider().getProviderId());
 
         try {
             Map responseBody = restClient.post()
@@ -47,7 +48,6 @@ public class KakaoAuthUnlinkClient implements SocialAuthUnlinkClient {
                     .toEntity(Map.class).getBody();
             log.info("카카오 유저의 연결을 끊었습니다. (회원번호: {})", responseBody.get("id"));
         } catch (OdyBadRequestException exception) {
-
         }
     }
 

--- a/backend/src/main/java/com/ody/member/service/MemberService.java
+++ b/backend/src/main/java/com/ody/member/service/MemberService.java
@@ -55,7 +55,7 @@ public class MemberService {
 
     @Transactional
     public void delete(Member member) {
-        kakaoAuthUnlinkClient.unlink(member.getAuthProvider().getProviderId());
+        kakaoAuthUnlinkClient.unlink(member);
 
         mateService.deleteAllByMember(member);
         memberRepository.delete(member);
@@ -65,7 +65,7 @@ public class MemberService {
     public void deleteV2(Member member) {
         ProviderType providerType = member.getAuthProvider().getProviderType();
         SocialAuthUnlinkClient socialAuthUnlinkClient = socialAuthUnlinkClientFactory.getClient(providerType);
-        socialAuthUnlinkClient.unlink(member.getAuthProvider().getProviderId());
+        socialAuthUnlinkClient.unlink(member);
 
         mateService.deleteAllByMember(member);
         memberRepository.delete(member);

--- a/backend/src/test/java/com/ody/auth/service/MemberAppleTokenServiceTest.java
+++ b/backend/src/test/java/com/ody/auth/service/MemberAppleTokenServiceTest.java
@@ -7,7 +7,7 @@ import com.ody.auth.domain.MemberAppleToken;
 import com.ody.common.BaseServiceTest;
 import com.ody.common.exception.OdyNotFoundException;
 import com.ody.member.domain.AuthProvider;
-import com.ody.member.domain.ProviderType;
+import com.ody.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,23 +17,22 @@ class MemberAppleTokenServiceTest extends BaseServiceTest {
     @Autowired
     private MemberAppleTokenService memberAppleTokenService;
 
-    @DisplayName("AuthProvider로 AppleRefreshToken을 조회한다.")
+    @DisplayName("memberId로 AppleRefreshToken을 조회한다.")
     @Test
     void findAppleRefreshTokenSuccess() {
         MemberAppleToken memberAppleToken = fixtureGenerator.generateMemberAppleToken();
+        Member member = memberAppleToken.getMember();
+        AuthProvider authProvider = member.getAuthProvider();
 
-        AuthProvider authProvider = memberAppleToken.getMember().getAuthProvider();
-        String appleRefreshToken = memberAppleTokenService.findAppleRefreshToken(authProvider);
+        MemberAppleToken appleRefreshToken = memberAppleTokenService.findByMemberId(member.getId());
 
-        assertThat(appleRefreshToken).isEqualTo(memberAppleToken.getAppleRefreshToken());
+        assertThat(appleRefreshToken.getAppleRefreshToken()).isEqualTo(memberAppleToken.getAppleRefreshToken());
     }
 
-    @DisplayName("AuthProvider로 AppleRefreshToken을 조회할 수 없으면 예외가 발생한다.")
+    @DisplayName("memberId로 AppleRefreshToken을 조회할 수 없으면 예외가 발생한다.")
     @Test
     void findAppleRefreshTokenException() {
-        AuthProvider authProvider = new AuthProvider(ProviderType.APPLE, "wrong-pid");
-
-        assertThatThrownBy(() -> memberAppleTokenService.findAppleRefreshToken(authProvider))
+        assertThatThrownBy(() -> memberAppleTokenService.findByMemberId(1L))
                 .isInstanceOf(OdyNotFoundException.class);
     }
 }

--- a/backend/src/test/java/com/ody/auth/service/kakao/KakaoAuthUnlinkClientTest.java
+++ b/backend/src/test/java/com/ody/auth/service/kakao/KakaoAuthUnlinkClientTest.java
@@ -38,15 +38,6 @@ class KakaoAuthUnlinkClientTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @TestConfiguration
-    static class FakeKakaoProperties {
-
-        @Bean
-        public KakaoProperties kakaoProperties() {
-            return new KakaoProperties("https://kapi.kakao.com/v1/user/unlink", "admin-key");
-        }
-    }
-
     @DisplayName("카카오 연결 끊기 성공")
     @Test
     void unlinkSuccess() throws JsonProcessingException {

--- a/backend/src/test/java/com/ody/auth/service/kakao/KakaoAuthUnlinkClientTest.java
+++ b/backend/src/test/java/com/ody/auth/service/kakao/KakaoAuthUnlinkClientTest.java
@@ -10,9 +10,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ody.auth.config.KakaoConfig;
 import com.ody.auth.config.KakaoProperties;
-import com.ody.auth.service.kakao.KakaoAuthUnlinkClient;
-import com.ody.auth.service.kakao.KakaoAuthUnlinkClientErrorHandler;
+import com.ody.common.Fixture;
 import com.ody.common.exception.OdyServerErrorException;
+import com.ody.member.domain.Member;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,17 +50,20 @@ class KakaoAuthUnlinkClientTest {
     @DisplayName("카카오 연결 끊기 성공")
     @Test
     void unlinkSuccess() throws JsonProcessingException {
-        Map<String, Object> response = Map.of("id", 123456789);
+        Member unlinkMember = Fixture.MEMBER1;
+        Map<String, Object> response = Map.of("id", unlinkMember.getAuthProvider().getProviderId());
         server.expect(requestTo("https://kapi.kakao.com/v1/user/unlink"))
                 .andRespond(withSuccess(objectMapper.writeValueAsString(response), MediaType.APPLICATION_JSON));
 
-        assertThatCode(() -> kakaoAuthUnlinkClient.unlink("123456789"))
+        assertThatCode(() -> kakaoAuthUnlinkClient.unlink(unlinkMember))
                 .doesNotThrowAnyException();
     }
 
     @DisplayName("카카오 연결 끊기 재시도")
     @Test
     void unlinkWithUnlinkedUser() throws JsonProcessingException {
+        Member unlinkMember = Fixture.MEMBER1;
+
         Map<String, Object> response = Map.of(
                 "msg", "NotRegisteredUserException",
                 "code", -101
@@ -70,13 +73,15 @@ class KakaoAuthUnlinkClientTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body(objectMapper.writeValueAsString(response)));
 
-        assertThatCode(() -> kakaoAuthUnlinkClient.unlink("123456789"))
+        assertThatCode(() -> kakaoAuthUnlinkClient.unlink(unlinkMember))
                 .doesNotThrowAnyException();
     }
 
     @DisplayName("카카오 연결 끊기 실패")
     @Test
     void unlinkException() throws JsonProcessingException {
+        Member unlinkMember = Fixture.MEMBER1;
+
         Map<String, Object> response = Map.of(
                 "msg", "IllegalParamException",
                 "code", -2
@@ -86,7 +91,7 @@ class KakaoAuthUnlinkClientTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .body(objectMapper.writeValueAsString(response)));
 
-        assertThatThrownBy(() -> kakaoAuthUnlinkClient.unlink("123456789"))
+        assertThatThrownBy(() -> kakaoAuthUnlinkClient.unlink(unlinkMember))
                 .isInstanceOf(OdyServerErrorException.class);
     }
 }

--- a/backend/src/test/java/com/ody/common/BaseServiceTest.java
+++ b/backend/src/test/java/com/ody/common/BaseServiceTest.java
@@ -1,6 +1,6 @@
 package com.ody.common;
 
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -63,8 +63,8 @@ public abstract class BaseServiceTest {
 
     @BeforeEach
     void setUp() {
-        doNothing().when(kakaoAuthUnlinkClient).unlink(anyString());
-        doNothing().when(appleRevokeTokenClient).unlink(anyString());
+        doNothing().when(kakaoAuthUnlinkClient).unlink(any());
+        doNothing().when(appleRevokeTokenClient).unlink(any());
 
         databaseCleaner.clear();
         applicationEvents.clear();

--- a/backend/src/test/java/com/ody/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/ody/member/controller/MemberControllerTest.java
@@ -1,6 +1,6 @@
 package com.ody.member.controller;
 
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
 import com.ody.auth.service.apple.AppleRevokeTokenClient;
@@ -32,8 +32,8 @@ class MemberControllerTest extends BaseControllerTest {
 
     @BeforeEach
     void setUp() {
-        doNothing().when(kakaoAuthUnlinkClient).unlink(anyString());
-        doNothing().when(appleRevokeTokenClient).unlink(anyString());
+        doNothing().when(kakaoAuthUnlinkClient).unlink(any());
+        doNothing().when(appleRevokeTokenClient).unlink(any());
     }
 
     @DisplayName("이미 삭제한 회원에 대한 회원 삭제 요청 시 204를 반환한다.")

--- a/backend/src/test/java/com/ody/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/ody/member/service/MemberServiceTest.java
@@ -70,7 +70,7 @@ class MemberServiceTest extends BaseServiceTest {
 
         memberService.deleteV2(member);
 
-        verify(kakaoAuthUnlinkClient, times(1)).unlink(member.getAuthProvider().getProviderId());
+        verify(kakaoAuthUnlinkClient, times(1)).unlink(member);
     }
 
     @DisplayName("애플 회원 탈퇴 시 애플 클라이언트가 호출된다.")
@@ -80,7 +80,7 @@ class MemberServiceTest extends BaseServiceTest {
 
         memberService.deleteV2(member);
 
-        verify(appleRevokeTokenClient, times(1)).unlink(member.getAuthProvider().getProviderId());
+        verify(appleRevokeTokenClient, times(1)).unlink(member);
     }
 
     @DisplayName("삭제 회원을 조회할 수 없다.")

--- a/backend/src/test/java/com/ody/scenario/member/MemberScenarioTest.java
+++ b/backend/src/test/java/com/ody/scenario/member/MemberScenarioTest.java
@@ -1,0 +1,194 @@
+package com.ody.scenario.member;
+
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+
+import com.ody.auth.dto.request.AppleAuthRequest;
+import com.ody.auth.dto.request.KakaoAuthRequest;
+import com.ody.auth.service.apple.AppleRevokeTokenClient;
+import com.ody.auth.service.apple.AppleValidateTokenClient;
+import com.ody.auth.service.kakao.KakaoAuthUnlinkClient;
+import com.ody.auth.token.AccessToken;
+import com.ody.common.BaseControllerTest;
+import com.ody.common.TokenFixture;
+import com.ody.member.domain.Member;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import jakarta.persistence.EntityManager;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestFactory;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.HttpHeaders;
+
+public class MemberScenarioTest extends BaseControllerTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @MockBean
+    private AppleValidateTokenClient appleValidateTokenClient;
+
+    @SpyBean
+    protected KakaoAuthUnlinkClient kakaoAuthUnlinkClient;
+
+    @SpyBean
+    protected AppleRevokeTokenClient appleRevokeTokenClient;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.when(appleValidateTokenClient.obtainRefreshToken(anyString()))
+                .thenReturn("test-refresh-token");
+        doNothing().when(appleRevokeTokenClient).unlink(any());
+
+        doNothing().when(kakaoAuthUnlinkClient).unlink(any());
+    }
+
+    @Nested
+    class AppleScenarioTest {
+
+        private Member member;
+
+        private AppleAuthRequest appleAuthRequest;
+
+        @DisplayName("에플 회원 - 가입 - 탈퇴 - 재가입 - 탈퇴 시나리오")
+        @TestFactory
+        Stream<DynamicTest> apple_ReAttendAndDeleteSameMember() {
+            return Stream.of(
+                    dynamicTest("애플 회원 가입", () -> {
+                        appleAuthRequest = dtoGenerator.generateAppleAuthRequest();
+
+                        RestAssured.given().log().all()
+                                .contentType(ContentType.JSON)
+                                .body(appleAuthRequest)
+                                .when()
+                                .post("/v1/auth/apple")
+                                .then()
+                                .statusCode(200);
+
+                        member = getUndeletedMemberByDeviceToken(appleAuthRequest.getDeviceToken());
+                    }),
+                    dynamicTest("애플 회원 탈퇴", () -> {
+                        AccessToken accessToken = TokenFixture.getValidAccessToken(member.getId());
+                        String authorization = "Bearer access-token=" + accessToken.getValue();
+
+                        RestAssured.given().log().all()
+                                .contentType(ContentType.JSON)
+                                .header(HttpHeaders.AUTHORIZATION, authorization)
+                                .when().log().all()
+                                .delete("/v2/members")
+                                .then()
+                                .statusCode(204);
+                    }),
+                    dynamicTest("애플 회원 재가입", () -> {
+                        RestAssured.given().log().all()
+                                .contentType(ContentType.JSON)
+                                .body(appleAuthRequest)
+                                .when()
+                                .post("/v1/auth/apple")
+                                .then()
+                                .statusCode(200);
+
+                        member = getUndeletedMemberByDeviceToken(appleAuthRequest.getDeviceToken());
+                    }),
+                    dynamicTest("애플 회원 탈퇴", () -> {
+                        AccessToken accessToken = TokenFixture.getValidAccessToken(member.getId());
+                        String authorization = "Bearer access-token=" + accessToken.getValue();
+
+                        Mockito.doNothing().when(appleRevokeTokenClient).unlink(any());
+
+                        RestAssured.given().log().all()
+                                .contentType(ContentType.JSON)
+                                .header(HttpHeaders.AUTHORIZATION, authorization)
+                                .when().log().all()
+                                .delete("/v2/members")
+                                .then()
+                                .statusCode(204);
+                    })
+            );
+        }
+    }
+
+    @Nested
+    class KakaoScenarioTest {
+
+        private Member member;
+
+        private KakaoAuthRequest kakaoAuthRequest;
+
+        @DisplayName("카카오 회원 - 가입 - 탈퇴 - 재가입 - 탈퇴 시나리오")
+        @TestFactory
+        Stream<DynamicTest> kako_ReAttendAndDeleteSameMember() {
+            return Stream.of(
+                    dynamicTest("카카오 회원 가입", () -> {
+                        kakaoAuthRequest = dtoGenerator.generateKakaoAuthRequest("provider-id", "device-token");
+
+                        RestAssured.given().log().all()
+                                .contentType(ContentType.JSON)
+                                .body(kakaoAuthRequest)
+                                .when()
+                                .post("/v1/auth/kakao")
+                                .then()
+                                .statusCode(200);
+
+                        member = getUndeletedMemberByDeviceToken(kakaoAuthRequest.getDeviceToken());
+                    }),
+                    dynamicTest("카카오 회원 탈퇴", () -> {
+                        AccessToken accessToken = TokenFixture.getValidAccessToken(member.getId());
+                        String authorization = "Bearer access-token=" + accessToken.getValue();
+
+                        RestAssured.given().log().all()
+                                .contentType(ContentType.JSON)
+                                .header(HttpHeaders.AUTHORIZATION, authorization)
+                                .when().log().all()
+                                .delete("/v2/members")
+                                .then()
+                                .statusCode(204);
+                    }),
+                    dynamicTest("카카오 회원 재가입", () -> {
+                        kakaoAuthRequest = dtoGenerator.generateKakaoAuthRequest(
+                                kakaoAuthRequest.getProviderId(),
+                                kakaoAuthRequest.getDeviceToken()
+                        );
+
+                        RestAssured.given().log().all()
+                                .contentType(ContentType.JSON)
+                                .body(kakaoAuthRequest)
+                                .when()
+                                .post("/v1/auth/kakao")
+                                .then()
+                                .statusCode(200);
+
+                        member = getUndeletedMemberByDeviceToken(kakaoAuthRequest.getDeviceToken());
+                    }),
+                    dynamicTest("카카오 재 회원 탈퇴", () -> {
+                        AccessToken accessToken = TokenFixture.getValidAccessToken(member.getId());
+                        String authorization = "Bearer access-token=" + accessToken.getValue();
+
+                        RestAssured.given().log().all()
+                                .contentType(ContentType.JSON)
+                                .header(HttpHeaders.AUTHORIZATION, authorization)
+                                .when().log().all()
+                                .delete("/v2/members")
+                                .then()
+                                .statusCode(204);
+                    })
+            );
+        }
+    }
+
+    private Member getUndeletedMemberByDeviceToken(String deviceToken) {
+        return (Member) entityManager.createNativeQuery(
+                        "select * from member where device_token=? and deleted_at is null", Member.class)
+                .setParameter(1, deviceToken)
+                .getSingleResult();
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -30,3 +30,7 @@ route:
 
 allowed-origins:
   api-call: testOrigin
+
+kakao:
+  url: https://kapi.kakao.com/v1/user/unlink
+  admin-key: admin-key


### PR DESCRIPTION
# 🚩 연관 이슈 
close #1072


<br>

# 📝 작업 내용

# 에러 원인
- cloud watch에서 이런 에러 로그를 발견했어요
```text
2025-10-12T23:39:08.055+09:00
Caused by: org.hibernate.NonUniqueResultException: Query did not return a unique result: 2 results were returned
	at org.hibernate.query.spi.AbstractSelectionQuery.uniqueElement(AbstractSelectionQuery.java:578)
	at org.hibernate.query.spi.AbstractSelectionQuery.getSingleResult(AbstractSelectionQuery.java:561)
	at org.springframework.data.jpa.repository.query.JpaQueryExecution$SingleEntityExecution.doExecute(JpaQueryExecution.java:223)
	at org.springframework.data.jpa.repository.query.JpaQueryExecution.execute(JpaQueryExecution.java:92)
	at org.springframework.data.jpa.repository.query.AbstractJpaQuery.doExecute(AbstractJpaQuery.java:152)
	at org.springframework.data.jpa.repository.query.AbstractJpaQuery.execute(AbstractJpaQuery.java:140)
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker.doInvoke(RepositoryMethodInvoker.java:170)
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker.invoke(RepositoryMethodInvoker.java:158)
	at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.doInvoke(QueryExecutorMethodInterceptor.java:164)
	at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.invoke(QueryExecutorMethodInterceptor.java:143)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.invoke(DefaultMethodInvokingMethodInterceptor.java:70)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:392)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:138)
	... 110 common frames omitted
```

- 에러를 특정하고자 dev DB랑 똑같이 로컬 환경을 세팅하고 삭제 요청을 했는데 동일한 에러가 발생하더라고요.

- 원인은, provider_id로 탈퇴유저를 특정하는데  유저가 재가입하면 소프트 delete로 인해 동일한 provider_id를 지닌 유저가 2명 이상일 수 있다는 점입니다.

- 실제로  현재 dev db를 보면 동일한 provider_id를 가진 멤버가 가입 → 탈퇴 → 가입을 반복하고 있어요.
즉, 해음의 provider_id를 지닌 row가 두개이고 하나는 삭제되어 있음
<img width="648" height="133" alt="image (36)" src="https://github.com/user-attachments/assets/1315bf2d-1ccf-4f04-8014-ca8ec6098b62" />


그런데, MembrAppleTokenService에서 Apple RefreshToken을 찾는 로직을 보면 member와 authProvider를 join해서 provider_id를 기준으로 구분하고 있어요.
→ 삭제했던 member와 현재 삭제를 시도하는 member의 Refresh Token이 둘다 조회되어 에러 발생

```java
	public String findAppleRefreshToken(AuthProvider authProvider) {
        return memberAppleTokenRepository.findByMember_AuthProvider(authProvider)
                .map(MemberAppleToken::getAppleRefreshToken)
                .orElseThrow(() -> new OdyNotFoundException("AppleRefreshToken을 찾을 수 없습니다."));
    }
```

---

# 개선 방향

기존에 authProvider로 찾는 로직은 가입 → 탈퇴 → 가입을 반복할 경우, 도메인 unique 조건, 2개 이상의 결과 반환 등의 에러 발생 가능성이 농후함 → application 내의 멤버 식별자인 memberId로 appleRefreshToken을 찾도록 수정했습니다.

```java
    public MemberAppleToken findByMemberId(long memberId) {
        return memberAppleTokenRepository.findByMemberId(memberId)
                .orElseThrow(() -> new OdyNotFoundException("AppleRefreshToken을 찾을 수 없습니다."));
    }
```

# 로컬 테스트 결과
→ 정상적으로 삭제됨을 로컬 테스트를 통해 확인
<img width="1268" height="248" alt="image (35)" src="https://github.com/user-attachments/assets/79989e2c-662c-4923-be41-2c138f6f65a4" />



# 다시 발생하지 않기 위한 테스트

시나리오 테스트를 작성했어요. RestClient를 감싸는 객체들(UnlinkClient, ValidateClient 등등 래핑 객체들)의 응답을 모킹하고 가입-탈퇴-재가입-재탈퇴 시나리오를 카카오, 애플 각각 붙여놓았습니다.

분명, 오늘 발생한 에러 원인을 커버하는 테스트는 아니에요. 그럼에도 해당 테스트로 인해 앞으로 에러가 어디서 발생한 것인지 빠르게 특정할 수 있습니다.
→ 테스트가 통과하는데 에러가 발생하면, RestClient  래핑 클래스 문제라고 생각하면 됨(Mocking 한 부분)
→ 테스트가 터지면 ⇒ 변경된 Service나 도메인 로직 문제라고 생각하면 됨.

<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
