### PR TITLE
[FEAT] 레디스 분산락을 통한 따닥 중복 문제 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.24.3'
+
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.testcontainers:testcontainers-bom:1.20.2'

--- a/backend/src/main/java/com/ody/common/annotation/DistributedLock.java
+++ b/backend/src/main/java/com/ody/common/annotation/DistributedLock.java
@@ -1,0 +1,20 @@
+package com.ody.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    String key();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 10L;
+}

--- a/backend/src/main/java/com/ody/common/aop/DistributedLockAspect.java
+++ b/backend/src/main/java/com/ody/common/aop/DistributedLockAspect.java
@@ -1,0 +1,77 @@
+package com.ody.common.aop;
+
+import com.ody.common.annotation.DistributedLock;
+import com.ody.common.exception.OdyServerErrorException;
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(distributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        String lockKey = createLockKey(
+                distributedLock.key(),
+                signature.getParameterNames(),
+                joinPoint.getArgs()
+        );
+
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            boolean acquired = lock.tryLock(
+                    distributedLock.waitTime(),
+                    distributedLock.leaseTime(),
+                    distributedLock.timeUnit()
+            );
+
+            if (!acquired) {
+                log.warn("Lock acquisition failed: {}", lockKey);
+                throw new OdyServerErrorException("락 획득에 실패했습니다.");
+            }
+
+            log.info("Lock acquired: {}", lockKey);
+            return joinPoint.proceed();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new OdyServerErrorException("Lock interrupted");
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.info("Lock released: {}", lockKey);
+            }
+        }
+    }
+
+    private String createLockKey(String key, String[] parameterNames, Object[] args) {
+        // SpEL을 사용한 동적 키 생성
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, String.class);
+    }
+}

--- a/backend/src/main/java/com/ody/common/config/RedisConfig.java
+++ b/backend/src/main/java/com/ody/common/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package com.ody.common.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -32,5 +35,18 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory);
         return container;
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + redisHost + ":" + redisPort)
+                .setConnectionPoolSize(50)
+                .setConnectionMinimumIdleSize(10)
+                .setIdleConnectionTimeout(10000)
+                .setConnectTimeout(10000)
+                .setTimeout(3000);
+        return Redisson.create(config);
     }
 }

--- a/backend/src/main/java/com/ody/mate/service/MateService.java
+++ b/backend/src/main/java/com/ody/mate/service/MateService.java
@@ -1,8 +1,10 @@
 package com.ody.mate.service;
 
+import com.ody.common.annotation.DistributedLock;
 import com.ody.common.aop.EnableDeletedFilter;
 import com.ody.common.exception.OdyBadRequestException;
 import com.ody.common.exception.OdyNotFoundException;
+import com.ody.common.exception.OdyServerErrorException;
 import com.ody.eta.domain.EtaStatus;
 import com.ody.eta.dto.request.MateEtaRequest;
 import com.ody.eta.service.EtaSchedulingService;
@@ -29,11 +31,14 @@ import com.ody.route.domain.DepartureTime;
 import com.ody.route.domain.RouteTime;
 import com.ody.route.service.RouteService;
 import com.ody.util.TimeUtil;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -53,6 +58,11 @@ public class MateService {
     private final EtaSchedulingService etaSchedulingService;
 
     @Transactional
+    @DistributedLock(
+            key = "'mate:create:' + #meeting.id + ':' + #member.id",
+            waitTime = 5,
+            leaseTime = 10
+    )
     public MateSaveResponseV2 saveAndSendNotifications(
             MateSaveRequestV2 mateSaveRequest,
             Member member,

--- a/backend/src/main/java/com/ody/route/service/ApiCallService.java
+++ b/backend/src/main/java/com/ody/route/service/ApiCallService.java
@@ -51,11 +51,13 @@ public class ApiCallService {
         return new ApiCallEnabledResponse(enabled);
     }
 
+    @Transactional
     public boolean getEnabledByClientType(ClientType clientType) {
         ApiCall apiCall = findOrSaveTodayApiCallByClientType(clientType);
         return apiCall.getEnabled();
     }
 
+    @Transactional
     public ApiCall findOrSaveTodayApiCallByClientType(ClientType clientType) {
         LocalDate now = LocalDate.now();
         return apiCallRepository.findByDateAndClientType(now, clientType)

--- a/backend/src/test/java/com/ody/common/RedisCacheCleaner.java
+++ b/backend/src/test/java/com/ody/common/RedisCacheCleaner.java
@@ -1,6 +1,7 @@
 package com.ody.common;
 
 import java.util.Set;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,11 @@ public class RedisCacheCleaner {
     @Autowired
     private StringRedisTemplate redisTemplate;
 
+    @Autowired
+    private RedissonClient redissonClient;
+
     public void clear() {
+        redissonClient.getKeys().flushdb();
         Set<String> keys = redisTemplate.keys(ALL_KEYS);
         if (keys != null && !keys.isEmpty()) {
             redisTemplate.delete(keys);

--- a/backend/src/test/java/com/ody/common/RedisTestContainersConfig.java
+++ b/backend/src/test/java/com/ody/common/RedisTestContainersConfig.java
@@ -1,6 +1,9 @@
 package com.ody.common;
 
 import java.time.Duration;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -43,5 +46,18 @@ public class RedisTestContainersConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory);
         return container;
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + redisContainer.getHost() + ":" + REDIS_PORT)
+                .setConnectionPoolSize(50)
+                .setConnectionMinimumIdleSize(10)
+                .setIdleConnectionTimeout(10000)
+                .setConnectTimeout(10000)
+                .setTimeout(3000);
+        return Redisson.create(config);
     }
 }

--- a/backend/src/test/java/com/ody/common/RedisTestContainersConfig.java
+++ b/backend/src/test/java/com/ody/common/RedisTestContainersConfig.java
@@ -52,7 +52,7 @@ public class RedisTestContainersConfig {
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()
-                .setAddress("redis://" + redisContainer.getHost() + ":" + REDIS_PORT)
+                .setAddress("redis://" + redisContainer.getHost() + ":" + redisContainer.getMappedPort(REDIS_PORT))
                 .setConnectionPoolSize(50)
                 .setConnectionMinimumIdleSize(10)
                 .setIdleConnectionTimeout(10000)

--- a/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/ody/meeting/service/MeetingServiceTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -259,6 +260,68 @@ class MeetingServiceTest extends BaseServiceTest {
 
         assertThatCode(() -> meetingService.saveMateAndSendNotifications(mateSaveRequest, member))
                 .doesNotThrowAnyException();
+    }
+
+    @DisplayName("이미 약속에 참여해 있으면 참여하지 못한다.")
+    @Test
+    void saveMateFail_When_AlreadyAttended() {
+        LocalDateTime oneMinutesLater = TimeUtil.nowWithTrim().plusMinutes(1L);
+        Meeting notOverdueMeeting = fixtureGenerator.generateMeeting(oneMinutesLater);
+        Member member = fixtureGenerator.generateMember();
+        MateSaveRequestV2 mateSaveRequest = dtoGenerator.generateMateSaveRequest(notOverdueMeeting);
+
+        meetingService.saveMateAndSendNotifications(mateSaveRequest, member);
+
+        assertThatThrownBy(() -> meetingService.saveMateAndSendNotifications(mateSaveRequest, member))
+                .isInstanceOf(OdyBadRequestException.class);
+    }
+
+    @DisplayName("회원의 약속 참여 동시성 문제가 발생하지 않는다")
+    @Test
+    void saveMate_ConCurrencyTest() throws InterruptedException {
+        // given
+        int threadCount = 2;
+        LocalDateTime oneMinutesLater = TimeUtil.nowWithTrim().plusMinutes(1L);
+        Meeting meeting = fixtureGenerator.generateMeeting(oneMinutesLater);
+        Member member = fixtureGenerator.generateMember();
+        MateSaveRequestV2 request = dtoGenerator.generateMateSaveRequest(meeting);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    try {
+                        meetingService.saveMateAndSendNotifications(request, member);
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        System.out.println(e.getMessage());
+                        failCount.incrementAndGet();
+                    }
+
+                } catch (InterruptedException ignored) {
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        // 모든 스레드 동시에 실행
+        startLatch.countDown();
+        doneLatch.await();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(threadCount - 1);
+
+        executorService.shutdown();
     }
 
     @DisplayName("지난 약속에 참여가 불가하다")


### PR DESCRIPTION
# 🚩 연관 이슈 
close #1080


<br>

# 📝 작업 내용

해음이 탈퇴 과정에서 에러가 난 원인
-따닥, 동시성 이슈로 인해 (member_id, meeting_id, deleted_at) 이 동일한 Mate 행이 두개 이상 삽입되어 있었음
- 삭제 시 deleted_at을 현재 시점으로 업데이트 시도 -> 유니크 조건 에러

=> 해결방안 : Redis 분산락을 활용한 동시성 이슈 해결

총 8가지 방식을 시도하고 가장 합리적이라 생각되는 걸 골랐습니다. 해당 과정은 블로그에 적어놓았어요!
https://hellobrocolli.tistory.com/220


<br>

# 🏞️ 스크린샷 (선택)


<br>

# 🗣️ 리뷰 요구사항 (선택)
